### PR TITLE
Fixed latest cve error for jackson-data-bind CVE-2018-7489.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
             **/api/external/client/dto/**,
             **/api/external/client/exceptions/**
         </sonar.test.exclusions>
+        <jackson.databind.version>2.8.11.1</jackson.databind.version>
     </properties>
 
     <dependencyManagement>
@@ -157,6 +158,12 @@
                 <groupId>io.springfox</groupId>
                 <artifactId>springfox-swagger2</artifactId>
                 <version>2.6.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.databind.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
https://github.com/FasterXML/jackson-databind/issues/1931