### PR TITLE
added to suppression file temporarily

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -140,4 +140,9 @@
         <gav regex="true">.*</gav>
         <cve>CVE-2018-1196</cve>
     </suppress>
+    <suppress>
+    	<notes><![CDATA[Allows remote attackers to execute arbitrary code or conduct external XML entity (XXE) attacks]]></notes>
+    	<gav regex="true">^javax\.servlet:jstl:1\.2$</gav>
+    	<cve>CVE-2015-0254</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
This is due to ff4j dependencies added recently to payment-app.  
**Apache Standard Taglibs before 1.2.3 allows remote attackers to execute arbitrary code or conduct external XML entity (XXE) attacks via a crafted XSLT extension in a (1) <x:parse> or (2) <x:transform> JSTL XML tag**

But we are using latest version 1.2.5 .
`  +--- org.ff4j:ff4j-web:1.7.1
     |    +---  #org.apache.taglibs:taglibs-standard-impl:1.2.5`

Need some investigation to find out the actual cause.