### PR TITLE
Fee volume float value truncate fix

### DIFF
--- a/api-contract/src/main/java/uk/gov/hmcts/payment/api/contract/FeeDto.java
+++ b/api-contract/src/main/java/uk/gov/hmcts/payment/api/contract/FeeDto.java
@@ -33,7 +33,7 @@ public class FeeDto {
 
     @Positive
     @Digits(integer = 10, fraction = 0, message = "Fee volume cannot have fractions and has to be non-negative")
-    private Integer volume;
+    private Double volume;
 
     @NotNull
     @Digits(integer = 10, fraction = 2, message = "Fee calculated amount cannot have more than 2 decimal places")

--- a/api-contract/src/test/java/uk/gov/hmcts/payment/api/contract/FeeDtoTest.java
+++ b/api-contract/src/test/java/uk/gov/hmcts/payment/api/contract/FeeDtoTest.java
@@ -1,19 +1,16 @@
 package uk.gov.hmcts.payment.api.contract;
 
-import java.util.Iterator;
-import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
-import javax.validation.constraints.Positive;
+import java.util.Iterator;
+import java.util.Set;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FeeDtoTest {
     private static Validator validator;
@@ -27,35 +24,34 @@ public class FeeDtoTest {
     @Test
     public void negativeFeeVolumeShouldFailValidation() {
         FeeDto feeDto = new FeeDto();
-        feeDto.setVolume(-1);
+        feeDto.setVolume(-1d);
 
         Set<ConstraintViolation<FeeDto>> violations = validator.validate(feeDto);
         Iterator<ConstraintViolation<FeeDto>> iterator = violations.iterator();
-        while (iterator.hasNext()) {
-            if (iterator.next().getMessage().equals("must be greater than 0")) {
-                assertTrue(true);
-                return;
-            }
-        }
-        assertTrue("Validation should catch a negative fee volume number", false);
+        assertThat(iterator).extracting(ConstraintViolation::getMessage)
+            .contains("must be greater than 0");
+    }
+    @Test
+    public void fractionFeeVolumeShouldFailValidation() {
+        FeeDto feeDto = new FeeDto();
+        feeDto.setVolume(1.5);
+
+        Set<ConstraintViolation<FeeDto>> violations = validator.validate(feeDto);
+        Iterator<ConstraintViolation<FeeDto>> iterator = violations.iterator();
+        assertThat(iterator).extracting(ConstraintViolation::getMessage)
+            .contains("Fee volume cannot have fractions and has to be non-negative");
     }
 
     @Test
     public void feeVolumeSetToZeroShouldFailValidation() {
         FeeDto feeDto = new FeeDto();
-        feeDto.setVolume(0);
+        feeDto.setVolume(0d);
 
         Set<ConstraintViolation<FeeDto>> violations = validator.validate(feeDto);
 
         Iterator<ConstraintViolation<FeeDto>> iterator = violations.iterator();
-        while (iterator.hasNext()) {
-            if (iterator.next().getMessage().equals("must be greater than 0")) {
-                assertTrue(true);
-                return;
-            }
-        }
-
-        assertTrue("Validation should catch fee volume set to zero", false);
+        assertThat(iterator).extracting(ConstraintViolation::getMessage)
+            .contains("must be greater than 0");
     }
 
 

--- a/api-contract/src/test/java/uk/gov/hmcts/payment/api/contract/PaymentDtoTest.java
+++ b/api-contract/src/test/java/uk/gov/hmcts/payment/api/contract/PaymentDtoTest.java
@@ -22,7 +22,7 @@ public class PaymentDtoTest {
     private final BigDecimal calculatedAmountForFeeWithVolume;
     private final String memoLine;
     private final String naturalAccountCode;
-    private final Integer volume;
+    private final Double volume;
     private final String feeNoVolumeCode;
     private final BigDecimal calculatedAmountForFeeNoVolume;
     private PaymentDto testDto;
@@ -57,7 +57,7 @@ public class PaymentDtoTest {
         calculatedAmountForFeeWithVolume = new BigDecimal(1);
         memoLine = "memoLine";
         naturalAccountCode = "naturalAccountCode";
-        volume = new Integer(1);
+        volume = new Double(1.0);
         feeNoVolumeCode = "X0002";
         calculatedAmountForFeeNoVolume = new BigDecimal(1);
 

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/CardPaymentDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/CardPaymentDtoMapper.java
@@ -103,7 +103,7 @@ public class CardPaymentDtoMapper {
             .calculatedAmount(feeDto.getCalculatedAmount())
             .code(feeDto.getCode())
             .version(feeDto.getVersion())
-            .volume(feeDto.getVolume() == null ? 1 : feeDto.getVolume())
+            .volume(feeDto.getVolume() == null ? 1 : feeDto.getVolume().intValue())
             .build();
     }
 
@@ -112,7 +112,7 @@ public class CardPaymentDtoMapper {
             .calculatedAmount(fee.getCalculatedAmount())
             .code(fee.getCode())
             .version(fee.getVersion())
-            .volume(fee.getVolume())
+            .volume(fee.getVolume().doubleValue())
             .build();
 
     }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/CardPaymentDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/CardPaymentDtoMapper.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.payment.api.util.PayStatusToPayHubStatus;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -112,7 +113,9 @@ public class CardPaymentDtoMapper {
             .calculatedAmount(fee.getCalculatedAmount())
             .code(fee.getCode())
             .version(fee.getVersion())
-            .volume(fee.getVolume().doubleValue())
+            .volume(Optional.ofNullable(fee.getVolume())
+                .map(v -> v.doubleValue())
+                .orElse(null))
             .build();
 
     }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/CreditAccountDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/CreditAccountDtoMapper.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.payment.api.util.PayStatusToPayHubStatus;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -179,7 +180,9 @@ public class CreditAccountDtoMapper {
         return FeeDto.feeDtoWith()
             .calculatedAmount(fee.getCalculatedAmount())
             .code(fee.getCode()).version(fee.getVersion())
-            .volume(fee.getVolume().doubleValue())
+            .volume(Optional.ofNullable(fee.getVolume())
+                .map(v -> v.doubleValue())
+                .orElse(null))
             .build();
 
     }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/CreditAccountDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/CreditAccountDtoMapper.java
@@ -171,7 +171,7 @@ public class CreditAccountDtoMapper {
         return PaymentFee.feeWith()
             .calculatedAmount(feeDto.getCalculatedAmount()).code(feeDto.getCode())
             .version(feeDto.getVersion())
-            .volume(feeDto.getVolume() == null ? 1 : feeDto.getVolume())
+            .volume(feeDto.getVolume() == null ? 1 : feeDto.getVolume().intValue())
             .build();
     }
 
@@ -179,7 +179,7 @@ public class CreditAccountDtoMapper {
         return FeeDto.feeDtoWith()
             .calculatedAmount(fee.getCalculatedAmount())
             .code(fee.getCode()).version(fee.getVersion())
-            .volume(fee.getVolume())
+            .volume(fee.getVolume().doubleValue())
             .build();
 
     }


### PR DESCRIPTION
…LOAT_AS_INT flag). This causes volume value truncate to integer (eg: from 1.5 to 1) and not throwing validation error.