### PR TITLE
Suppress owasp warning for CVE-2016-7048 as no version resolving the …

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -150,5 +150,9 @@
     	<gav regex="true">^javax\.servlet:jstl:1\.2$</gav>
     	<cve>CVE-2015-0254</cve>
    </suppress>
+    <suppress>
+        <notes>CVE-2016-7048: only for Postgres lt 9.6 and we use 9.6 on Azure.  Also only impacts the installer.</notes>
+        <cve>CVE-2016-7048</cve>
+    </suppress>
 
 </suppressions>


### PR DESCRIPTION
…issue is available yet. Also, we don't manage PG installation on Azure.