### PR TITLE
Pay-1355: Service Callback URL

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -30,7 +30,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 
 withPipeline(type, product, app) {
-    setVaultName('payment-shared')
+    setVaultName('ccpay')
     loadVaultSecrets(secrets)
     enableDockerBuild()
     enableDeployToAKS()

--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ access to urls /users/999/payments/\*, any request to /users/{OTHER_ID}/payments
 * **Refunds**. Although, both HMCTS Payment Gateway and GOV.UK Pay implement refund endpoints, they **WILL NOT WORK** due to limitations
 of MoJ financial arrangements  & back-office systems.
 
+### Building
+The project uses [Gradle](https://gradle.org) as a build tool but you don't have install it locally since there is a
+`./gradlew` wrapper script.  
+
+To build project please execute the following command:
+
+```bash
+$ ./gradlew build
+```
+### Tests
+
+This project uses [TestContainers](https://www.testcontainers.org/usage/database_containers.html#jdbc-url) for database support.
+Docker must be installed on the machine you are running tests on and docker environment should have more than 2GB free disk space. 
+
+Windows users may need to enable this [setting](https://github.com/testcontainers/testcontainers-java/issues/350)
+
+To run all unit tests please execute the following command:
+
+```bash
+$ ./gradlew test
+```
+
 ### Endpoints
 
 * POST /users/{userId}/payments - create payment

--- a/api-contract/src/main/java/uk/gov/hmcts/payment/api/contract/CardPaymentRequest.java
+++ b/api-contract/src/main/java/uk/gov/hmcts/payment/api/contract/CardPaymentRequest.java
@@ -47,6 +47,9 @@ public class CardPaymentRequest {
 
     private CurrencyCode currency;
 
+    @JsonProperty("service_callback_url")
+    private String serviceCallbackUrl;
+
     @NotEmpty
     @JsonProperty("site_id")
     private String siteId;

--- a/api-contract/src/main/java/uk/gov/hmcts/payment/api/contract/CardPaymentRequest.java
+++ b/api-contract/src/main/java/uk/gov/hmcts/payment/api/contract/CardPaymentRequest.java
@@ -47,9 +47,6 @@ public class CardPaymentRequest {
 
     private CurrencyCode currency;
 
-    @JsonProperty("service_callback_url")
-    private String serviceCallbackUrl;
-
     @NotEmpty
     @JsonProperty("site_id")
     private String siteId;

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java
@@ -68,13 +68,14 @@ public class CardPaymentController {
     @ResponseBody
     public ResponseEntity<PaymentDto> createCardPayment(
         @RequestHeader(value = "return-url") String returnURL,
+        @RequestHeader(value = "service-callback-url", required = false) String serviceCallbackUrl,
         @Valid @RequestBody CardPaymentRequest request) throws CheckDigitException {
         String paymentReference = PaymentReference.getInstance().getNext();
 
         int amountInPence = request.getAmount().multiply(new BigDecimal(100)).intValue();
 
         PaymentFeeLink paymentLink = delegatingPaymentService.create(paymentReference, request.getDescription(), returnURL, request.getCcdCaseNumber(), request.getCaseReference(), request.getCurrency().getCode(), request.getSiteId(), request.getService().getName(), paymentDtoMapper.toFees(request.getFees()), amountInPence,
-        request.getServiceCallbackUrl());
+            serviceCallbackUrl);
 
         return new ResponseEntity<>(paymentDtoMapper.toCardPaymentDto(paymentLink), CREATED);
     }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java
@@ -5,7 +5,6 @@ import org.apache.commons.validator.routines.checkdigit.CheckDigitException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -74,9 +73,8 @@ public class CardPaymentController {
 
         int amountInPence = request.getAmount().multiply(new BigDecimal(100)).intValue();
 
-        PaymentFeeLink paymentLink = delegatingPaymentService.create(amountInPence, paymentReference,
-            request.getDescription(), returnURL, request.getCcdCaseNumber(), request.getCaseReference(),
-            request.getCurrency().getCode(), request.getSiteId(), request.getService().getName(), paymentDtoMapper.toFees(request.getFees()));
+        PaymentFeeLink paymentLink = delegatingPaymentService.create(paymentReference, request.getDescription(), returnURL, request.getCcdCaseNumber(), request.getCaseReference(), request.getCurrency().getCode(), request.getSiteId(), request.getService().getName(), paymentDtoMapper.toFees(request.getFees()), amountInPence,
+        request.getServiceCallbackUrl());
 
         return new ResponseEntity<>(paymentDtoMapper.toCardPaymentDto(paymentLink), CREATED);
     }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentReference.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentReference.java
@@ -1,15 +1,10 @@
 package uk.gov.hmcts.payment.api.controllers;
 
-import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import java.security.SecureRandom;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Month;
-import java.time.temporal.TemporalAdjusters;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class PaymentReference {
 
@@ -19,7 +14,7 @@ public class PaymentReference {
     }
 
     public static PaymentReference getInstance() {
-        if ( obj == null ) {
+        if (obj == null) {
             obj = new PaymentReference();
         }
 
@@ -30,7 +25,7 @@ public class PaymentReference {
         SecureRandom random = new SecureRandom();
 
         DateTime dateTime = new DateTime(DateTimeZone.UTC);
-        long dateTimeinMillis = dateTime.getMillis()/100;
+        long dateTimeinMillis = dateTime.getMillis() / 100;
 
         String nextVal = String.format("%010d", dateTimeinMillis);
         return LocalDateTime.now().getYear() + "-" + nextVal;

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
@@ -33,6 +33,7 @@ public class PaymentDtoMapper {
         return PaymentDto.payment2DtoWith()
             .status(PayStatusToPayHubStatus.valueOf(payment.getStatus().toLowerCase()).mapedStatus)
             .reference(payment.getReference())
+            .paymentGroupReference(paymentFeeLink.getPaymentReference())
             .dateCreated(payment.getDateCreated())
             .links(new PaymentDto.LinksDto(
                 payment.getNextUrl() == null ? null : new PaymentDto.LinkDto(payment.getNextUrl(), "GET"),
@@ -57,6 +58,7 @@ public class PaymentDtoMapper {
             .channel(payment.getPaymentChannel().getName())
             .method(payment.getPaymentMethod().getName())
             .externalReference(payment.getExternalReference())
+            .paymentGroupReference(paymentFeeLink.getPaymentReference())
             .externalProvider(payment.getPaymentProvider() != null ? payment.getPaymentProvider().getName() : null)
             .fees(toFeeDtos(fees))
             .links(new PaymentDto.LinksDto(null,
@@ -71,6 +73,7 @@ public class PaymentDtoMapper {
         return PaymentDto.payment2DtoWith()
             .reference(payment.getReference())
             .amount(payment.getAmount())
+            .paymentGroupReference(paymentFeeLink.getPaymentReference())
             .status(PayStatusToPayHubStatus.valueOf(payment.getPaymentStatus().getName()).mapedStatus)
             .statusHistories(toStatusHistoryDtos(payment.getStatusHistories()))
             .build();

--- a/api/src/main/resources/db/changelog/db.changelog-0.0.9.yaml
+++ b/api/src/main/resources/db/changelog/db.changelog-0.0.9.yaml
@@ -34,13 +34,13 @@ databaseChangeLog:
           tableName: payment
 
 - changeSet:
-    id: 1600000000000-1
+    id: 1600000000000-2
     author: eduardo
     changes:
     - addColumn:
         columns:
         - column:
             name: service_callback_url
-            type: varchar(255)
-        tableName: payment_fee_link
+            type: varchar(2000)
+        tableName: payment
 

--- a/api/src/main/resources/db/changelog/db.changelog-0.0.9.yaml
+++ b/api/src/main/resources/db/changelog/db.changelog-0.0.9.yaml
@@ -32,3 +32,15 @@ databaseChangeLog:
               name: reported_date_offline
               type: TIMESTAMP WITHOUT TIME ZONE
           tableName: payment
+
+- changeSet:
+    id: 1600000000000-1
+    author: eduardo
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: service_callback_url
+            type: varchar(255)
+        tableName: payment_fee_link
+

--- a/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/CardPaymentControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/CardPaymentControllerTest.java
@@ -148,7 +148,7 @@ public class CardPaymentControllerTest extends PaymentsDataUtil {
 
         PaymentDto paymentsResponse = objectMapper.readValue(result2.getResponse().getContentAsString(), PaymentDto.class);
 
-        assertEquals("http://payments.com", db.findByReference(paymentsResponse.getPaymentGroupReference()).getServiceCallbackUrl());
+        assertEquals("http://payments.com", db.findByReference(paymentsResponse.getPaymentGroupReference()).getPayments().get(0).getServiceCallbackUrl());
 
         assertNotNull(paymentDto);
         assertEquals("Initiated", paymentDto.getStatus());

--- a/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/CardPaymentControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/CardPaymentControllerTest.java
@@ -294,8 +294,10 @@ public class CardPaymentControllerTest extends PaymentsDataUtil {
             .build();
         PaymentFee fee = PaymentFee.feeWith().calculatedAmount(new BigDecimal("121.11")).version("1").code("FEE0123").build();
 
-        PaymentFeeLink paymentFeeLink = db.create(paymentFeeLinkWith().paymentReference("2018-15186161221").payments(Arrays.asList(payment)).fees(Arrays.asList(fee)));
+        PaymentFeeLink paymentFeeLink = db.create(paymentFeeLinkWith().paymentReference("2018-15186161221").payments(Arrays.asList(payment)).fees(Arrays.asList(fee)).serviceCallbackUrl("http://payments.com"));
         payment.setPaymentLink(paymentFeeLink);
+
+        assertEquals("http://payments.com", paymentFeeLink.getServiceCallbackUrl());
 
         Payment savedPayment = paymentFeeLink.getPayments().get(0);
 

--- a/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/PaymentDbBackdoor.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/PaymentDbBackdoor.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.payment.api.componenttests;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.payment.api.model.Payment;
+import uk.gov.hmcts.payment.api.model.Payment2Repository;
 import uk.gov.hmcts.payment.api.model.PaymentFeeLink;
 import uk.gov.hmcts.payment.api.model.PaymentFeeLink.PaymentFeeLinkBuilder;
 import uk.gov.hmcts.payment.api.model.PaymentFeeLinkRepository;
@@ -14,6 +15,10 @@ public class PaymentDbBackdoor {
     @Autowired
     private PaymentFeeLinkRepository paymentFeeLinkRepository;
 
+    @Autowired
+    private Payment2Repository paymentRepository;
+
+
     public PaymentFeeLink create(PaymentFeeLinkBuilder paymentFeeLink) {
         return paymentFeeLinkRepository.save(paymentFeeLink.build());
     }
@@ -21,6 +26,5 @@ public class PaymentDbBackdoor {
     public PaymentFeeLink findByReference(String reference) {
         return paymentFeeLinkRepository.findByPaymentReference(reference).orElseThrow(PaymentNotFoundException::new);
     }
-
 
 }

--- a/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/PaymentReconciliationComponentTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/PaymentReconciliationComponentTest.java
@@ -10,7 +10,10 @@ import uk.gov.hmcts.payment.api.model.PaymentFeeLink;
 import uk.gov.hmcts.payment.api.v1.componenttests.TestUtil;
 
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -40,7 +43,6 @@ public class PaymentReconciliationComponentTest extends TestUtil {
             .build());
 
 
-
         Date fromDate = new Date();
         MutableDateTime mFromDate = new MutableDateTime(fromDate);
         mFromDate.addDays(-1);
@@ -55,7 +57,7 @@ public class PaymentReconciliationComponentTest extends TestUtil {
 
     @Test
     public void testFindPaymetsBetweenGivenInValidDates() throws Exception {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+
         String paymentRef3 = UUID.randomUUID().toString();
         PaymentFeeLink paymentFeeLink = paymentFeeLinkRepository.save(paymentFeeLinkWith().paymentReference(paymentRef3)
             .payments(Arrays.asList(paymentsDataUtil.getCardPaymentsData().get(1)))
@@ -67,7 +69,6 @@ public class PaymentReconciliationComponentTest extends TestUtil {
             .payments(Arrays.asList(paymentsDataUtil.getCardPaymentsData().get(1)))
             .fees(Arrays.asList(paymentsDataUtil.getFeesData().get(0)))
             .build());
-
 
 
         Date fromDate = new Date();

--- a/api/src/test/java/uk/gov/hmcts/payment/api/v1/componenttests/sugar/RestActions.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/v1/componenttests/sugar/RestActions.java
@@ -45,6 +45,11 @@ public class RestActions {
         return this;
     }
 
+    public RestActions withHeader(String header, String value) {
+        httpHeaders.add(header, value);
+        return this;
+    }
+
     public RestActions withAuthorizedUser(String userId) {
         String token = UUID.randomUUID().toString();
         userRequestAuthorizer.registerToken(token, userId);

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -4,8 +4,8 @@ locals {
   local_env = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "aat" : "saat" : var.env}"
   local_ase = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "core-compute-aat" : "core-compute-saat" : local.aseName}"
 
-  previewVaultName = "payment-shared-aat"
-  nonPreviewVaultName = "payment-shared-${var.env}"
+  previewVaultName = "${var.core_product}-aat"
+  nonPreviewVaultName = "${var.core_product}-${var.env}"
   vaultName = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultName : local.nonPreviewVaultName}"
 
   s2sUrl = "http://rpe-service-auth-provider-${local.local_env}.service.${local.local_ase}.internal"
@@ -18,7 +18,7 @@ locals {
 
 data "azurerm_key_vault" "payment_key_vault" {
   name = "${local.vaultName}"
-  resource_group_name = "payment-${local.local_env}"
+  resource_group_name = "${var.core_product}-${local.local_env}"
 }
 
 data "azurerm_key_vault_secret" "gov_pay_keys_reference" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -31,7 +31,7 @@ variable "microservice" {
 
 // disabled liquibase temporarily - enable for new db changes build and then disable again
 variable "liquibase_enabled" {
-  default = "false"
+  default = "true"
 }
 
 variable "database_name" {

--- a/model/src/main/java/uk/gov/hmcts/payment/api/model/Payment.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/model/Payment.java
@@ -124,4 +124,7 @@ public class Payment {
     @JoinColumn(name = "payment_id", referencedColumnName = "id", nullable = false)
     private List<StatusHistory> statusHistories;
 
+    @Column(name = "service_callback_url")
+    private String serviceCallbackUrl;
+
 }

--- a/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentFeeLink.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentFeeLink.java
@@ -11,8 +11,6 @@ import javax.persistence.*;
 import java.util.Date;
 import java.util.List;
 
-
-
 @Entity
 @Data
 @Builder(builderMethodName = "paymentFeeLinkWith")
@@ -43,5 +41,8 @@ public class PaymentFeeLink {
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "payment_link_id", referencedColumnName = "id", nullable = false)
     private List<PaymentFee> fees;
+
+    @Column(name = "service_callback_url")
+    private String serviceCallbackUrl;
 
 }

--- a/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentFeeLink.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentFeeLink.java
@@ -42,7 +42,4 @@ public class PaymentFeeLink {
     @JoinColumn(name = "payment_link_id", referencedColumnName = "id", nullable = false)
     private List<PaymentFee> fees;
 
-    @Column(name = "service_callback_url")
-    private String serviceCallbackUrl;
-
 }

--- a/model/src/main/java/uk/gov/hmcts/payment/api/service/DelegatingPaymentService.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/service/DelegatingPaymentService.java
@@ -8,8 +8,7 @@ import java.util.List;
 
 public interface DelegatingPaymentService<T, ID> {
 
-    T create(int amount, String paymentReference, String description, String returnUrl,
-             String ccdCaseNumber, String caseReference, String currency, String siteId, String serviceType, List<PaymentFee> fees) throws CheckDigitException;
+    T create(String paymentReference, String description, String returnUrl, String ccdCaseNumber, String caseReference, String currency, String siteId, String serviceType, List<PaymentFee> fees, int amount, String serviceCallbackUrl) throws CheckDigitException;
 
     T retrieve(ID id);
 

--- a/model/src/main/java/uk/gov/hmcts/payment/api/service/LoggingPaymentService.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/service/LoggingPaymentService.java
@@ -40,9 +40,8 @@ public class LoggingPaymentService implements DelegatingPaymentService<PaymentFe
     }
 
     @Override
-    public PaymentFeeLink create(int amount, @NonNull String paymentReference, @NonNull String description, @NonNull String returnUrl,
-                                 String ccdCaseNumber, String caseReference, String currency, String siteId, String serviceType, List<PaymentFee> fees) throws CheckDigitException {
-        PaymentFeeLink paymentFeeLink = delegate.create(amount, paymentReference, description, returnUrl, ccdCaseNumber, caseReference, currency, siteId, serviceType, fees);
+    public PaymentFeeLink create(@NonNull String paymentReference, @NonNull String description, @NonNull String returnUrl, String ccdCaseNumber, String caseReference, String currency, String siteId, String serviceType, List<PaymentFee> fees, int amount, String serviceCallbackUrl) throws CheckDigitException {
+        PaymentFeeLink paymentFeeLink = delegate.create(paymentReference, description, returnUrl, ccdCaseNumber, caseReference, currency, siteId, serviceType, fees, amount, serviceCallbackUrl);
 
         Payment payment = paymentFeeLink.getPayments().get(0);
         LOG.info("Payment event", StructuredArguments.entries(ImmutableMap.of(

--- a/model/src/main/java/uk/gov/hmcts/payment/api/service/UserAwareDelegatingCreditAccountPaymentService.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/service/UserAwareDelegatingCreditAccountPaymentService.java
@@ -27,11 +27,11 @@ public class UserAwareDelegatingCreditAccountPaymentService implements CreditAcc
     private static final Logger LOG = LoggerFactory.getLogger(UserAwareDelegatingCreditAccountPaymentService.class);
 
     private final static String PAYMENT_CHANNEL_ONLINE = "online";
-    private final static String PAYMENT_PROVIDER_MIDDLE_OFFICE_PROVIDER = "middle office provider";
+
     private final static String PAYMENT_METHOD = "payment by account";
-    private final static String PAYMENT_STATUS_CREATED = "created";
+
     private final static String PAYMENT_STATUS_PENDING = "pending";
-    private final static String PAYMENT_METHOD_BY_ACCOUNT =  "payment by account";
+    private final static String PAYMENT_METHOD_BY_ACCOUNT = "payment by account";
 
     private final PaymentFeeLinkRepository paymentFeeLinkRepository;
     private final PaymentStatusRepository paymentStatusRepository;
@@ -62,34 +62,34 @@ public class UserAwareDelegatingCreditAccountPaymentService implements CreditAcc
     public PaymentFeeLink create(Payment creditAccount, List<PaymentFee> fees, String paymentGroupRef) throws CheckDigitException {
         LOG.debug("Create credit account payment with PaymentGroupReference: {}", paymentGroupRef);
 
-            Payment payment = null;
-            try {
-                payment = Payment.paymentWith()
-                    .amount(creditAccount.getAmount())
-                    .description(creditAccount.getDescription())
-                    .returnUrl(creditAccount.getReturnUrl())
-                    .ccdCaseNumber(creditAccount.getCcdCaseNumber())
-                    .caseReference(creditAccount.getCaseReference())
-                    .currency(creditAccount.getCurrency())
-                    .siteId(creditAccount.getSiteId())
-                    .serviceType(creditAccount.getServiceType())
-                    .s2sServiceName(serviceIdSupplier.get())
-                    .customerReference(creditAccount.getCustomerReference())
-                    .organisationName(creditAccount.getOrganisationName())
-                    .pbaNumber(creditAccount.getPbaNumber())
-                    .paymentChannel(paymentChannelRepository.findByNameOrThrow(PAYMENT_CHANNEL_ONLINE))
-                    .paymentMethod(paymentMethodRepository.findByNameOrThrow(PAYMENT_METHOD_BY_ACCOUNT))
-                    .paymentStatus(paymentStatusRepository.findByNameOrThrow(PAYMENT_STATUS_PENDING))
-                    .reference(paymentReferenceUtil.getNext())
-                    .statusHistories(Arrays.asList(StatusHistory.statusHistoryWith()
-                        .status(paymentStatusRepository.findByNameOrThrow(PAYMENT_STATUS_PENDING).getName())
-                        .build()))
-                    .build();
-            } catch (CheckDigitException e) {
-                LOG.error("Error in generating check digit for the payment reference, {}", e);
-            }
+        Payment payment = null;
+        try {
+            payment = Payment.paymentWith()
+                .amount(creditAccount.getAmount())
+                .description(creditAccount.getDescription())
+                .returnUrl(creditAccount.getReturnUrl())
+                .ccdCaseNumber(creditAccount.getCcdCaseNumber())
+                .caseReference(creditAccount.getCaseReference())
+                .currency(creditAccount.getCurrency())
+                .siteId(creditAccount.getSiteId())
+                .serviceType(creditAccount.getServiceType())
+                .s2sServiceName(serviceIdSupplier.get())
+                .customerReference(creditAccount.getCustomerReference())
+                .organisationName(creditAccount.getOrganisationName())
+                .pbaNumber(creditAccount.getPbaNumber())
+                .paymentChannel(paymentChannelRepository.findByNameOrThrow(PAYMENT_CHANNEL_ONLINE))
+                .paymentMethod(paymentMethodRepository.findByNameOrThrow(PAYMENT_METHOD_BY_ACCOUNT))
+                .paymentStatus(paymentStatusRepository.findByNameOrThrow(PAYMENT_STATUS_PENDING))
+                .reference(paymentReferenceUtil.getNext())
+                .statusHistories(Arrays.asList(StatusHistory.statusHistoryWith()
+                    .status(paymentStatusRepository.findByNameOrThrow(PAYMENT_STATUS_PENDING).getName())
+                    .build()))
+                .build();
+        } catch (CheckDigitException e) {
+            LOG.error("Error in generating check digit for the payment reference, {}", e);
+        }
 
-        PaymentFeeLink result =  paymentFeeLinkRepository.save(PaymentFeeLink.paymentFeeLinkWith()
+        PaymentFeeLink result = paymentFeeLinkRepository.save(PaymentFeeLink.paymentFeeLinkWith()
             .paymentReference(paymentGroupRef)
             .payments(Arrays.asList(payment))
             .fees(fees)

--- a/model/src/main/java/uk/gov/hmcts/payment/api/service/UserAwareDelegatingPaymentService.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/service/UserAwareDelegatingPaymentService.java
@@ -100,6 +100,7 @@ public class UserAwareDelegatingPaymentService implements DelegatingPaymentServi
             .paymentProvider(paymentProviderRespository.findByNameOrThrow(PAYMENT_PROVIDER_GOVPAY))
             .paymentStatus(paymentStatusRepository.findByNameOrThrow(PAYMENT_STATUS_CREATED))
             .reference(paymentReference)
+            .serviceCallbackUrl(serviceCallbackUrl)
             .build();
         fillTransientDetails(payment, govPayPayment);
 
@@ -112,7 +113,6 @@ public class UserAwareDelegatingPaymentService implements DelegatingPaymentServi
 
         PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().paymentReference(paymentGroupReference)
             .payments(Arrays.asList(payment))
-            .serviceCallbackUrl(serviceCallbackUrl)
             .fees(fees)
             .build();
 

--- a/model/src/main/java/uk/gov/hmcts/payment/api/service/UserAwareDelegatingPaymentService.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/service/UserAwareDelegatingPaymentService.java
@@ -110,11 +110,15 @@ public class UserAwareDelegatingPaymentService implements DelegatingPaymentServi
             .message(govPayPayment.getState().getMessage())
             .build()));
 
-        PaymentFeeLink paymentFeeLink = paymentFeeLinkRepository.save(PaymentFeeLink.paymentFeeLinkWith().paymentReference(paymentGroupReference)
+        PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().paymentReference(paymentGroupReference)
             .payments(Arrays.asList(payment))
             .serviceCallbackUrl(serviceCallbackUrl)
             .fees(fees)
-            .build());
+            .build();
+
+        payment.setPaymentLink(paymentFeeLink);
+
+        paymentFeeLink = paymentFeeLinkRepository.save(paymentFeeLink);
 
         auditRepository.trackPaymentEvent("CREATE_CARD_PAYMENT", payment, fees);
         return paymentFeeLink;
@@ -125,7 +129,7 @@ public class UserAwareDelegatingPaymentService implements DelegatingPaymentServi
     public PaymentFeeLink retrieve(String paymentReference) {
         Payment payment = findSavedPayment(paymentReference);
 
-        PaymentFeeLink paymentFeeLink = payment.getPaymentLink();
+        final PaymentFeeLink paymentFeeLink = payment.getPaymentLink();
 
         String paymentService = payment.getS2sServiceName();
 

--- a/model/src/main/java/uk/gov/hmcts/payment/api/service/UserAwareDelegatingPaymentService.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/service/UserAwareDelegatingPaymentService.java
@@ -83,12 +83,10 @@ public class UserAwareDelegatingPaymentService implements DelegatingPaymentServi
 
     @Override
     @Transactional
-    public PaymentFeeLink create(int amount, @NonNull String paymentGroupReference, @NonNull String description, @NonNull String returnUrl,
-                                 String ccdCaseNumber, String caseReference, String currency, String siteId, String serviceType, List<PaymentFee> fees) throws CheckDigitException {
+    public PaymentFeeLink create(@NonNull String paymentGroupReference, @NonNull String description, @NonNull String returnUrl, String ccdCaseNumber, String caseReference, String currency, String siteId, String serviceType, List<PaymentFee> fees, int amount, String serviceCallbackUrl) throws CheckDigitException {
         String paymentReference = paymentReferenceUtil.getNext();
 
-        GovPayPayment govPayPayment = delegate.create(amount, paymentReference, description, returnUrl,
-            ccdCaseNumber, caseReference, currency, siteId, serviceType, fees);
+        GovPayPayment govPayPayment = delegate.create(paymentReference, description, returnUrl, ccdCaseNumber, caseReference, currency, siteId, serviceType, fees, amount, serviceCallbackUrl);
 
         //Build PaymentLink obj
         Payment payment = Payment.paymentWith().userId(userIdSupplier.get())
@@ -114,6 +112,7 @@ public class UserAwareDelegatingPaymentService implements DelegatingPaymentServi
 
         PaymentFeeLink paymentFeeLink = paymentFeeLinkRepository.save(PaymentFeeLink.paymentFeeLinkWith().paymentReference(paymentGroupReference)
             .payments(Arrays.asList(payment))
+            .serviceCallbackUrl(serviceCallbackUrl)
             .fees(fees)
             .build());
 

--- a/model/src/main/java/uk/gov/hmcts/payment/api/service/govpay/GovPayDelegatingPaymentService.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/service/govpay/GovPayDelegatingPaymentService.java
@@ -33,16 +33,7 @@ public class GovPayDelegatingPaymentService implements DelegatingPaymentService<
     }
 
     @Override
-    public GovPayPayment create(int amount,
-                                String reference,
-                                @NonNull String description,
-                                @NonNull String returnUrl,
-                                String ccdCaseNumber,
-                                String caseReference,
-                                String currency,
-                                String siteId,
-                                String serviceType,
-                                List<PaymentFee> fees) {
+    public GovPayPayment create(String reference, @NonNull String description, @NonNull String returnUrl, String ccdCaseNumber, String caseReference, String currency, String siteId, String serviceType, List<PaymentFee> fees, int amount, String serviceCallbackUrl) {
         String key = keyForService();
         return govPayClient.createPayment(key, new CreatePaymentRequest(amount, reference, description, returnUrl));
     }

--- a/model/src/test/java/uk/gov/hmcts/payment/api/service/LoggingPaymentServiceTest.java
+++ b/model/src/test/java/uk/gov/hmcts/payment/api/service/LoggingPaymentServiceTest.java
@@ -36,9 +36,8 @@ public class LoggingPaymentServiceTest {
     @Test
     public void createCardPaymentTest() throws Exception {
         when(userIdSupplier.get()).thenReturn("USER_ID");
-        when(delegatingPaymentService.create(10000, "paymentReference", "description", "https://www.google.com",
-            "ccdCaseNumber", "caseReference", "GBP", "siteId", "divorce",
-            Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal(10000)).code("X0001").version("1").build()))).thenReturn(PaymentFeeLink.paymentFeeLinkWith().id(1)
+        when(delegatingPaymentService.create("paymentReference", "description", "https://www.google.com", "ccdCaseNumber", "caseReference", "GBP", "siteId", "divorce", Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal(10000)).code("X0001").version("1").build()), 10000,
+        )).thenReturn(PaymentFeeLink.paymentFeeLinkWith().id(1)
             .payments(Arrays.asList(Payment.paymentWith()
                 .id(1)
                 .amount(new BigDecimal("10000"))
@@ -55,9 +54,8 @@ public class LoggingPaymentServiceTest {
                 .build()))
             .build());
 
-        PaymentFeeLink paymentFeeLink = loggingPaymentService.create(10000, "paymentReference", "description", "https://www.google.com",
-            "ccdCaseNumber", "caseReference", "GBP", "siteId", "divorce",
-            Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal(10000)).code("X0001").version("1").build()));
+        PaymentFeeLink paymentFeeLink = loggingPaymentService.create("paymentReference", "description", "https://www.google.com", "ccdCaseNumber", "caseReference", "GBP", "siteId", "divorce", Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal(10000)).code("X0001").version("1").build()), 10000,
+        );
         assertNotNull(paymentFeeLink);
         paymentFeeLink.getPayments().stream().forEach(p -> {
             assertEquals(p.getReference(), "RC-1518-9479-8089-4415");

--- a/model/src/test/java/uk/gov/hmcts/payment/api/service/LoggingPaymentServiceTest.java
+++ b/model/src/test/java/uk/gov/hmcts/payment/api/service/LoggingPaymentServiceTest.java
@@ -36,7 +36,7 @@ public class LoggingPaymentServiceTest {
     @Test
     public void createCardPaymentTest() throws Exception {
         when(userIdSupplier.get()).thenReturn("USER_ID");
-        when(delegatingPaymentService.create("paymentReference", "description", "https://www.google.com", "ccdCaseNumber", "caseReference", "GBP", "siteId", "divorce", Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal(10000)).code("X0001").version("1").build()), 10000,
+        when(delegatingPaymentService.create("paymentReference", "description", "https://www.google.com", "ccdCaseNumber", "caseReference", "GBP", "siteId", "divorce", Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal(10000)).code("X0001").version("1").build()), 10000, null
         )).thenReturn(PaymentFeeLink.paymentFeeLinkWith().id(1)
             .payments(Arrays.asList(Payment.paymentWith()
                 .id(1)
@@ -54,7 +54,7 @@ public class LoggingPaymentServiceTest {
                 .build()))
             .build());
 
-        PaymentFeeLink paymentFeeLink = loggingPaymentService.create("paymentReference", "description", "https://www.google.com", "ccdCaseNumber", "caseReference", "GBP", "siteId", "divorce", Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal(10000)).code("X0001").version("1").build()), 10000,
+        PaymentFeeLink paymentFeeLink = loggingPaymentService.create("paymentReference", "description", "https://www.google.com", "ccdCaseNumber", "caseReference", "GBP", "siteId", "divorce", Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal(10000)).code("X0001").version("1").build()), 10000, null
         );
         assertNotNull(paymentFeeLink);
         paymentFeeLink.getPayments().stream().forEach(p -> {

--- a/model/src/test/java/uk/gov/hmcts/payment/api/service/govpay/GovPayDelegatingPaymentServiceTest.java
+++ b/model/src/test/java/uk/gov/hmcts/payment/api/service/govpay/GovPayDelegatingPaymentServiceTest.java
@@ -59,10 +59,9 @@ public class GovPayDelegatingPaymentServiceTest {
             .returnUrl("https://www.google.com")
             .build());
 
-        GovPayPayment govPayPayment = govPayCardPaymentService.create(10000, "reference", "description", "https://www.google.com",
-            "ccdCaseNumer", "caseReference", "GBP", "siteId", "divorce",
-            Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal("10000")).code("feeCode").version("1")
-                .build()));
+        GovPayPayment govPayPayment = govPayCardPaymentService.create("reference", "description", "https://www.google.com", "ccdCaseNumer", "caseReference", "GBP", "siteId", "divorce", Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal("10000")).code("feeCode").version("1")
+            .build()), 10000,
+        );
         assertNotNull(govPayPayment);
         assertEquals(govPayPayment.getAmount(), new Integer(10000));
         assertEquals(govPayPayment.getState().getStatus(), "created");

--- a/model/src/test/java/uk/gov/hmcts/payment/api/service/govpay/GovPayDelegatingPaymentServiceTest.java
+++ b/model/src/test/java/uk/gov/hmcts/payment/api/service/govpay/GovPayDelegatingPaymentServiceTest.java
@@ -60,7 +60,7 @@ public class GovPayDelegatingPaymentServiceTest {
             .build());
 
         GovPayPayment govPayPayment = govPayCardPaymentService.create("reference", "description", "https://www.google.com", "ccdCaseNumer", "caseReference", "GBP", "siteId", "divorce", Arrays.asList(PaymentFee.feeWith().calculatedAmount(new BigDecimal("10000")).code("feeCode").version("1")
-            .build()), 10000,
+            .build()), 10000, null
         );
         assertNotNull(govPayPayment);
         assertEquals(govPayPayment.getAmount(), new Integer(10000));


### PR DESCRIPTION
- Added service-callback-url to POST /payments as an optional header that if provided stores this URL on payment-fee-link

- Fixed a bug where calls to GET /card-payments/{reference} could fail inmediately after the payment was created because the cached entity was missing a reference to the parent

- Fixed a bug where several PaymentFeeLink to PaymentDto conversions were missing paymentGroupReference
