### PR TITLE
changing to property instead of env variable

### DIFF
--- a/api/src/main/resources/bootstrap.yaml
+++ b/api/src/main/resources/bootstrap.yaml
@@ -17,4 +17,4 @@ spring:
         ccpay.liberata-keys-oauth2-client-secret: LIBERATA_OAUTH2_CLIENT_SECRET
         ccpay.liberata-keys-oauth2-username: LIBERATA_OAUTH2_USERNAME
         ccpay.liberata-keys-oauth2-password: LIBERATA_OAUTH2_PASSWORD
-        ccpay.payment-api-POSTGRES-PASS: SPRING_DATASOURCE_PASSWORD
+        ccpay.payment-api-POSTGRES-PASS: spring.datasource.password


### PR DESCRIPTION
Changing to property instead of env variable as env variables take precedence while using relaxed binding for spring properties.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-1009

### Change description ###

Changing to property instead of env variable as env variables take precedence while using relaxed binding for spring properties.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
