### PR TITLE
fix docker health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ENV JAVA_OPTS ""
 
 COPY build/libs/$APP /opt/app/
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy= curl --silent --fail http://localhost:8080/health
+HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy= wget -q --spider http://localhost:8080/health || exit 1 


### PR DESCRIPTION
curl is not part of the image anymore that result to a status "unhealthy" for the container.
I replaced it with wget from the spring-boot-template.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
