### PR TITLE
Pay 1695 Pay 1696

### DIFF
--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
@@ -180,6 +180,7 @@ public class PaymentDtoMapper {
         return FeeDto.feeDtoWith()
             .calculatedAmount(calculatedAmount)
             .code(fee.getCode())
+            .netAmount(fee.getNetAmount())
             .version(fee.getVersion())
             .volume(fee.getVolume())
             .ccdCaseNumber(fee.getCcdCaseNumber())

--- a/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/PbaControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/PbaControllerTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.payment.api.v1.componenttests.sugar.RestActions;
 import java.math.BigDecimal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -99,5 +100,6 @@ public class PbaControllerTest extends PaymentsDataUtil {
 
         assertEquals(1, paymentsResponse.getPayments().size());
         assertEquals(netAmount,  paymentsResponse.getPayments().get(0).getFees().get(0).getCalculatedAmount());
+        assertNotNull("net_amount should be set", paymentsResponse.getPayments().get(0).getFees().get(0).getNetAmount());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PAY-1695
https://tools.hmcts.net/jira/browse/PAY-1696

### Change description ###

Added net_amount to feeDTO. If net_amount is not null for fee for a payment, then GET endpoint for payments will use net amount for the calculated amount.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x ] Yes
[ ] No
```
