### PR TITLE
Moving to hmcts version of liquibase which performs better DB locking

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -73,7 +73,7 @@ dependencies {
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.9.9.2'
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version:'2.9.0'
   compile group: 'io.springfox', name: 'springfox-swagger2', version:'2.9.0'
-  compile group: 'org.liquibase', name: 'liquibase-core', version:'3.7.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'liquibase-core', version:'3.8.1'
   compile group: 'com.microsoft.azure', name: 'azure-servicebus-spring-boot-starter', version: '2.1.6'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
   compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.7.0'

--- a/api/liquibase.gradle
+++ b/api/liquibase.gradle
@@ -3,7 +3,7 @@ configurations {
 }
 
 dependencies {
-    liquibase group: 'org.liquibase.ext', name: 'liquibase-hibernate5', version: 3.6
+    liquibase group: 'org.liquibase.ext', name: 'liquibase-hibernate5', version: 3.8
 }
 
 //loading properties file.
@@ -32,6 +32,7 @@ task migratePostgresDatabase(type: JavaExec) {
     classpath sourceSets.main.runtimeClasspath
     classpath configurations.liquibase
     main = "liquibase.integration.commandline.Main"
+    systemProperty "liquibase.useDbLock", true
 
     def urlString = project.hasProperty("dburl") ? "jdbc:postgresql://$dburl" : liquibaseProps.getProperty('url')
     def user = project.hasProperty("flyway.user") ? "${rootProject.properties['flyway.user']}" : liquibaseProps.getProperty('username')

--- a/api/src/main/java/uk/gov/hmcts/PaymentApiApplication.java
+++ b/api/src/main/java/uk/gov/hmcts/PaymentApiApplication.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import liquibase.configuration.GlobalConfiguration;
+import liquibase.configuration.LiquibaseConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -30,6 +32,10 @@ public class PaymentApiApplication {
 
     public static void main(String[] args) {
         try {
+            //Setting Liquibase DB Lock property before Spring starts up.
+            LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .setUseDbLock(true);
             SpringApplication.run(PaymentApiApplication.class, args);
         } catch (RuntimeException ex) {
             LOG.error(Markers.fatal, "Application crashed with error message: ", ex);


### PR DESCRIPTION
This is based on hmcts/liquibase#2

Idea is to move everyone over to flyway. This is temporary fix to resolve locking issues causing multiple failures in PRs and Demo especially. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
