### PR TITLE
SNI-3349: Update to test search fee link with case id.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG APP_INSIGHTS_AGENT_VERSION=2.5.1
-FROM hmctspublic.azurecr.io/base/java:openjdk-11-distroless-1.4
+FROM hmctspublic.azurecr.io/base/java:11-distroless
 
 COPY lib/AI-Agent.xml /opt/app/
 COPY build/libs/payment-app.jar /opt/app/

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     testCompile group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     testCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.7'
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-thymeleaf'
-    testCompile group: 'org.testcontainers', name: 'postgresql', version: '1.15.1'
+    testCompile group: 'org.testcontainers', name: 'postgresql', version: '1.15.3'
     testCompile 'org.awaitility:awaitility:3.1.6'
     testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
     testCompile 'org.powermock:powermock-api-mockito2:2.0.9'

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/PayFeeLinkRepositoryStub.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/PayFeeLinkRepositoryStub.java
@@ -83,6 +83,11 @@ public class PayFeeLinkRepositoryStub implements PaymentFeeLinkRepository {
     }
 
     @Override
+    public Optional<PaymentFeeLink> findByPaymentReferenceAndCcdCaseNumber(String id, String ccdCaseNumber) {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<List<PaymentFeeLink>> findByCcdCaseNumber(String ccdCaseNumber) {
         return Optional.empty();
     }

--- a/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentFeeLinkRepository.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentFeeLinkRepository.java
@@ -12,6 +12,8 @@ public interface PaymentFeeLinkRepository extends CrudRepository<PaymentFeeLink,
 
     Optional<PaymentFeeLink> findByPaymentReference(String id);
 
+    Optional<PaymentFeeLink> findByPaymentReferenceAndCcdCaseNumber(String id, String ccdCaseNumber);
+
     Optional<List<PaymentFeeLink>> findByCcdCaseNumber(String ccdCaseNumber);
 
 }

--- a/model/src/test/java/uk/gov/hmcts/payment/api/service/RemissionServiceTest.java
+++ b/model/src/test/java/uk/gov/hmcts/payment/api/service/RemissionServiceTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.payment.api.v1.model.exceptions.InvalidPaymentGroupReference
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -101,6 +102,35 @@ public class RemissionServiceTest {
             .build();
 
         when(paymentFeeLinkRepository.findByPaymentReference("2019-123456799")).thenReturn(Optional.ofNullable(paymentFeeLink));
+
+        RemissionServiceRequest remissionServiceRequest = RemissionServiceRequest.remissionServiceRequestWith()
+            .paymentGroupReference("2019-123456799")
+            .ccdCaseNumber("1111-2222-3333-4444")
+            .beneficiaryName("testCreateRemission")
+            .hwfAmount(new BigDecimal("100.99"))
+            .hwfReference("hwf123456789")
+            .fee(fee)
+            .build();
+
+        PaymentFeeLink res = remissionService.createRetrospectiveRemission(remissionServiceRequest, paymentFeeLink.getPaymentReference(), 1);
+        assertThat(res).isNotNull();
+        assertThat(res.getPaymentReference()).isEqualTo(paymentFeeLink.getPaymentReference());
+
+        verify(paymentFeeLinkRepository, atLeastOnce()).findByPaymentReference(paymentFeeLink.getPaymentReference());
+    }
+
+    @Test
+    public void createPartialRemissionWithPaymentGroupReferenceAndCcdCaseNumberTest() throws Exception {
+        Remission remission = getRemission();
+        PaymentFee fee = getFee();
+
+        PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith()
+            .paymentReference("2019-123456799")
+            .remissions(Collections.singletonList(remission))
+            .fees(Arrays.asList(fee))
+            .build();
+
+        when(paymentFeeLinkRepository.findByPaymentReferenceAndCcdCaseNumber("2019-123456799", "1111-2222-3333-4444")).thenReturn(Optional.ofNullable(paymentFeeLink));
 
         RemissionServiceRequest remissionServiceRequest = RemissionServiceRequest.remissionServiceRequestWith()
             .paymentGroupReference("2019-123456799")

--- a/reference-data/build.gradle
+++ b/reference-data/build.gradle
@@ -9,5 +9,5 @@ dependencies {
         exclude(module: 'commons-logging')
     }
 
-    testCompile group: 'org.testcontainers', name: 'postgresql', version: '1.15.1'
+    testCompile group: 'org.testcontainers', name: 'postgresql', version: '1.15.3'
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SNI-3349


### Change description ###
Update to fallback to searching for remission though payment reference and case id if payment reference alone doesn't bring back a unique value.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
