### PR TITLE
Add nfdiv-case-api to gov pay keys

### DIFF
--- a/charts/payment-api/values.yaml
+++ b/charts/payment-api/values.yaml
@@ -137,6 +137,8 @@ java:
           alias: gov.pay.auth.key.cmc_claim_store
         - name: gov-pay-keys-divorce
           alias: gov.pay.auth.key.divorce_frontend
+        - name: gov-pay-keys-divorce
+          alias: gov.pay.auth.key.nfdiv_case_api
         - name: gov-pay-keys-probate
           alias: gov.pay.auth.key.probate_frontend
         - name: gov-pay-keys-iac


### PR DESCRIPTION
Allow nfdiv-case-api to use the divorce gov pay key