### PR TITLE
PAY-5998 fix pact verification failures

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -229,7 +229,9 @@ task providerContractTest(type: Test) {
     testClassesDirs = sourceSets.contractTest.output.classesDirs
     classpath = sourceSets.contractTest.runtimeClasspath
     systemProperty 'pact.rootDir', "pacts"
-    systemProperty 'pact.verifier.publishResults', System.getProperty('pact.verifier.publishResults')
+    if (project.hasProperty('pact.verifier.publishResults')) {
+        systemProperty 'pact.verifier.publishResults', project.property('pact.verifier.publishResults')
+    }
     systemProperty 'pact.provider.version', project.pactVersion
 
 }

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CardPaymentProviderTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CardPaymentProviderTest.java
@@ -232,6 +232,7 @@ class CardPaymentProviderTest {
             .statusHistories(Arrays.asList(statusHistory))
             .dateUpdated(now)
             .dateCreated(now)
+            .nextUrl("http://nexturl.test")
             .build();
 
         PaymentFee fee = feeWith().calculatedAmount(new BigDecimal("99.99")).version("1").code("FEE000" + number).volume(1).build();

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CardPaymentProviderTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CardPaymentProviderTest.java
@@ -232,7 +232,6 @@ class CardPaymentProviderTest {
             .statusHistories(Arrays.asList(statusHistory))
             .dateUpdated(now)
             .dateCreated(now)
-            .nextUrl("http://nexturl.test")
             .build();
 
         PaymentFee fee = feeWith().calculatedAmount(new BigDecimal("99.99")).version("1").code("FEE000" + number).volume(1).build();

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/ServiceRequestProviderTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/ServiceRequestProviderTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(SpringExtension.class)
 @Provider("payment_accounts")
 @PactBroker(scheme = "${PACT_BROKER_SCHEME:http}", host = "${PACT_BROKER_URL:localhost}", port = "${PACT_BROKER_PORT:80}", consumerVersionSelectors = {
-    @VersionSelector(tag = "Dev")})
+    @VersionSelector(tag = "master")})
 @Import(ServiceRequestProviderTestConfiguration.class)
 @IgnoreNoPactsToVerify
 class ServiceRequestProviderTest {

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/ServiceRequestProviderTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/ServiceRequestProviderTest.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.MultiValueMap;
 import uk.gov.hmcts.payment.api.controllers.ServiceRequestController;
 import uk.gov.hmcts.payment.api.domain.service.ServiceRequestDomainService;
 import uk.gov.hmcts.payment.api.dto.OnlineCardPaymentRequest;
@@ -35,7 +34,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(SpringExtension.class)
 @Provider("payment_accounts")
 @PactBroker(scheme = "${PACT_BROKER_SCHEME:http}", host = "${PACT_BROKER_URL:localhost}", port = "${PACT_BROKER_PORT:80}", consumerVersionSelectors = {
-    @VersionSelector(tag = "master")})
+    @VersionSelector(tag = "Dev")})
 @Import(ServiceRequestProviderTestConfiguration.class)
 @IgnoreNoPactsToVerify
 class ServiceRequestProviderTest {

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/ServiceRequestProviderTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/ServiceRequestProviderTest.java
@@ -8,10 +8,12 @@ import au.com.dius.pact.provider.junitsupport.State;
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
 import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
 import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.apache.commons.validator.routines.checkdigit.CheckDigitException;
 import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Import;
@@ -19,10 +21,15 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.MultiValueMap;
 import uk.gov.hmcts.payment.api.controllers.ServiceRequestController;
 import uk.gov.hmcts.payment.api.domain.service.ServiceRequestDomainService;
-import uk.gov.hmcts.payment.api.dto.ServiceRequestResponseDto;
-import uk.gov.hmcts.payment.api.dto.servicerequest.ServiceRequestDto;
+import uk.gov.hmcts.payment.api.dto.OnlineCardPaymentRequest;
+import uk.gov.hmcts.payment.api.dto.OnlineCardPaymentResponse;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -32,6 +39,8 @@ import static org.mockito.Mockito.when;
 @Import(ServiceRequestProviderTestConfiguration.class)
 @IgnoreNoPactsToVerify
 class ServiceRequestProviderTest {
+
+    private static final String DATE_TIME_FORMAT_T_HH_MM_SS_SSS = "yyyy-MM-dd'T'HH:mm:ss.SSS";
 
     @Value("${PACT_BRANCH_NAME}")
     String branchName;
@@ -59,11 +68,20 @@ class ServiceRequestProviderTest {
     }
 
     @State({"A Service Request Can be Created for a valid Payload"})
-    public void toReturnAccountDetails() throws JSONException {
+    public void toReturnAccountDetails() throws JSONException, CheckDigitException, ParseException {
 
-        ServiceRequestResponseDto serviceRequestResponseDto
-            = ServiceRequestResponseDto.serviceRequestResponseDtoWith().serviceRequestReference("2020-1234567890123").build();
-        when(serviceRequestDomainServiceMock.create(any(ServiceRequestDto.class), any(MultiValueMap.class))).thenReturn(serviceRequestResponseDto);
+        SimpleDateFormat formatter = new SimpleDateFormat(DATE_TIME_FORMAT_T_HH_MM_SS_SSS);
+        Date creationDate = formatter.parse("2022-09-05T11:09:04.308");
+
+        OnlineCardPaymentResponse onlineCardPaymentResponse
+            = OnlineCardPaymentResponse.onlineCardPaymentResponseWith()
+            .externalReference("csfopuk3a6r0e405cqtl9ef5br")
+            .nextUrl("https://www.payments.service.gov.uk/secure/3790460a-5932-4364-bba1-75390b4ec758")
+            .paymentReference("RC-1662-3761-4393-1823")
+            .status("Initiated")
+            .dateCreated(creationDate)
+            .build();
+        when(serviceRequestDomainServiceMock.create(any(OnlineCardPaymentRequest.class), eq("2022-1662375472431"), eq("https://localhost"), ArgumentMatchers.isNull())).thenReturn(onlineCardPaymentResponse);
 
     }
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/OnlineCardPaymentResponse.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/OnlineCardPaymentResponse.java
@@ -26,6 +26,5 @@ public class OnlineCardPaymentResponse {
     private String externalReference;
     private String status;
     private String nextUrl;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ", timezone = "GMT")
     private Date dateCreated;
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/OnlineCardPaymentResponse.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/OnlineCardPaymentResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.payment.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -25,5 +26,6 @@ public class OnlineCardPaymentResponse {
     private String externalReference;
     private String status;
     private String nextUrl;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ", timezone = "GMT")
     private Date dateCreated;
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/OnlineCardPaymentResponse.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/OnlineCardPaymentResponse.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.payment.api.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -27,7 +27,7 @@
         <cve>CVE-2021-22044</cve>
         <cve>CVE-2022-22969</cve>
     </suppress>
-    <suppress until="2024-01-31">
+    <suppress until="2024-03-31">
         <notes>
             adal4j version 1.3.0 in combination with jackson-databind has interface changes in DBUtils that cause unit tests to fail.
         </notes>
@@ -88,7 +88,7 @@
         </notes>
         <cve>CVE-2022-45688</cve>
     </suppress>
-    <suppress until="2024-01-31">
+    <suppress until="2024-03-31">
         <notes>
             Postgres version 42.4.18 in combination with jackson-databind has interface changes in DBUtils that cause unit tests to fail.
         </notes>
@@ -152,7 +152,7 @@
         <cve>CVE-2022-22978</cve>
         <cve>CVE-2022-22976</cve>
     </suppress>
-    <suppress until="2024-01-31">
+    <suppress until="2024-03-31">
         <notes>
             tomcat-embed-core version 9.0.73'in combination with jackson-databind has interface changes in DBUtils that cause unit tests to fail.
         </notes>


### PR DESCRIPTION

### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-5998


### Change description ###
Some contracts in the pact broker are no longer being verified.
For consumer probate_caveatsFrontEnd and provider payment_cardPayment there are two null pointer issues that probably started happening after the Java 17 upgrade, that brought with it Spring Boot and Mockito upgrades.
Specifically for Mockito at some point the keyword 'any' stopped matching null https://github.com/mockito/mockito/issues/1188 
Issue 1: Mock statement not operating in CardPaymentProviderTest.
Whereas previously a null was passed in (possibly unintentionally), and it was accepted by 'any', the paymentFeeLinkRepositoryMock would still return an instance of PaymentFeeLink. Under the stricter conditions of the new Mockito however this failure of null to match the specified any(PaymentFeeLink.class) resulted in the mock statement not operating and so a null pointer arose, which prevented the contract from being verified. Because the contract was in the Pending state this didn't cause a test failure and so went unnoticed.
Issue 2: No applicationContext made available to CardPaymentController.
Likely a subtle change in how SpringBoot unit tests handle contexts and autowiring.
The context is imported from CardPaymentProviderTestConfiguration and PaymentServiceImpl should in theory by made available and injected into CardPaymentController. Although this class isn't passed into the autowired constructor, it does feature as an autowired dependency. Because it's not automatically injected, we can explicitly grab it from the context, although we have to set the context on the CardPaymentController. 

For consumer prl_cos and provider payment_accounts the contract had never been verified because the consumer is misconfigured and is wrongly looking for payment_api. Once you correct this, the verification fails because the mocks have been wrongly setup. In ServiceRequestProviderTest the object we need is OnlineCardPaymentResponse and not ServiceRequestResponseDto. In addition to this, the @JsonFormat annotation is needed.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
