### PR TITLE
PAY-6779: Allow retry on failed PBA Liberata calls

### DIFF
--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestController.java
@@ -171,6 +171,10 @@ public class ServiceRequestController {
 
         // Idempotency Check - Find any idempotency records, if found then potentially we have a duplicate payment.
         List<IdempotencyKeys> duplicatePaymentIdempotencyRows = idempotencyService.findTheRecordByRequestHashcode(requestHashCode);
+
+        // Remove idempontency records from list which have an error response from Liberata but are allowed to be retried.
+        duplicatePaymentIdempotencyRows = idempotencyService.filterRecordsWithAcceptableLiberataHttpResponse(duplicatePaymentIdempotencyRows);
+
         Optional<IdempotencyKeys> currentIdempotencyKeyRow = idempotencyService.findTheRecordByIdempotencyKey(idempotencyKey).stream().findFirst();
         if (!duplicatePaymentIdempotencyRows.isEmpty() || currentIdempotencyKeyRow.isPresent()) {
             return processDuplicateServiceRequestPayment(duplicatePaymentIdempotencyRows, currentIdempotencyKeyRow, objectMapper,

--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/IdempotencyService.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/IdempotencyService.java
@@ -9,4 +9,6 @@ public interface IdempotencyService {
     Optional<IdempotencyKeys> findTheRecordByIdempotencyKey(String idempotencyKeyToCheck);
 
     List<IdempotencyKeys> findTheRecordByRequestHashcode(Integer requestHashcode);
+
+    List<IdempotencyKeys> filterRecordsWithAcceptableLiberataHttpResponse(List<IdempotencyKeys> idempotencyKeysList);
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/IdempotencyServiceImpl.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/IdempotencyServiceImpl.java
@@ -5,14 +5,20 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.payment.api.model.IdempotencyKeys;
 import uk.gov.hmcts.payment.api.model.IdempotencyKeysRepository;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 public class IdempotencyServiceImpl implements IdempotencyService {
 
     @Autowired
     private IdempotencyKeysRepository idempotencyKeysRepository;
+
+    private static final int HTTP_CODE_ALLOWABLE_RETRIES[] = { 504, 412, 402 };
 
     @Override
     public Optional<IdempotencyKeys> findTheRecordByIdempotencyKey(String idempotencyKeyToCheck) {
@@ -21,6 +27,17 @@ public class IdempotencyServiceImpl implements IdempotencyService {
 
     @Override
     public List<IdempotencyKeys> findTheRecordByRequestHashcode(Integer requestHashcode) {
-        return idempotencyKeysRepository.findByRequestHashcode(requestHashcode);
+        List<IdempotencyKeys> idempotencyKeyRows =
+            idempotencyKeysRepository.findByRequestHashcode(requestHashcode);
+
+        // Return all Idempotency records which are either still pending (payment in progress)
+        // or completed and do not have one of the known valid http responses which can allow a retry of the payment.
+        idempotencyKeyRows = idempotencyKeyRows.stream().filter(keys ->
+            (!keys.getResponseStatus().equals(IdempotencyKeys.ResponseStatusType.completed) ||
+                (keys.getResponseStatus().equals(IdempotencyKeys.ResponseStatusType.completed) &&
+                 !Arrays.stream(HTTP_CODE_ALLOWABLE_RETRIES).anyMatch(keys.getResponseCode()::equals))
+                )).collect(Collectors.toList());
+
+        return idempotencyKeyRows;
     }
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainServiceImpl.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainServiceImpl.java
@@ -417,6 +417,7 @@ public class ServiceRequestDomainServiceImpl implements ServiceRequestDomainServ
             idempotencyKeysRepository.saveAndFlush(idempotencyRecord);
 
         } catch (DataIntegrityViolationException exception) {
+            LOG.error("An error occurred writing the idempotency record. ", exception);
             responseEntity = new ResponseEntity<>("Too many requests. PBA Payment currently is in progress for this serviceRequest", HttpStatus.TOO_EARLY);
         }
 

--- a/api/src/test/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestControllerTest.java
@@ -324,7 +324,7 @@ public class ServiceRequestControllerTest {
     }
 
     @Test
-    public void createPBAPaymentWithServiceRequestFailDueToConflictHascode() throws Exception {
+    public void createPBAPaymentWithServiceRequestFailDueToConflictHashcode() throws Exception {
 
         //Creation of serviceRequest-reference
         String serviceRequestReferenceResult = getServiceRequestReference();
@@ -338,7 +338,6 @@ public class ServiceRequestControllerTest {
             .organisationName("sommin")
             .customerReference("testCustReference").
             build();
-
 
         AccountDto liberataAccountResponse = AccountDto.accountDtoWith()
             .accountNumber("PBAFUNC12345")

--- a/api/src/test/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestControllerTest.java
@@ -97,6 +97,9 @@ public class ServiceRequestControllerTest {
     PaymentGroupDtoMapper paymentGroupDtoMapper;
 
     @MockBean
+    private IdempotencyKeysRepository idempotencyKeysRepository;
+
+    @Autowired
     private IdempotencyService idempotencyService;
 
     @Autowired
@@ -172,7 +175,6 @@ public class ServiceRequestControllerTest {
             .organisationName("sommin")
             .customerReference("testCustReference").
                 build();
-
 
         AccountDto liberataAccountResponse = AccountDto.accountDtoWith()
             .accountNumber("PBAFUNC12345")
@@ -288,8 +290,8 @@ public class ServiceRequestControllerTest {
         List<IdempotencyKeys> resultDupKeys = List.of(idempotencyKeys);
         Optional<IdempotencyKeys> resultCurrentKey = Optional.of(idempotencyKeys);
 
-        when(idempotencyService.findTheRecordByRequestHashcode(any())).thenReturn(resultDupKeys);
-        when(idempotencyService.findTheRecordByIdempotencyKey(any())).thenReturn(resultCurrentKey);
+        when(idempotencyKeysRepository.findByRequestHashcode(any())).thenReturn(resultDupKeys);
+        when(idempotencyKeysRepository.findByIdempotencyKey(any())).thenReturn(resultCurrentKey);
         when(accountService.retrieve("PBAFUNC12345")).thenReturn(liberataAccountResponse);
 
         ServiceRequestPaymentBo serviceRequestPaymentBo = ServiceRequestPaymentBo.serviceRequestPaymentBoWith().
@@ -320,6 +322,66 @@ public class ServiceRequestControllerTest {
         MvcResult successServiceRequestPaymentResult = restActions
             .post("/service-request/" + serviceRequestReferenceResult + "/pba-payments", serviceRequestPaymentDto)
             .andExpect(status().isConflict())
+            .andReturn();
+    }
+
+    @Test
+    public void createPBAPaymentWithServiceRequestSuccessAfterInitialGatewayTimeout() throws Exception {
+
+        //Creation of serviceRequest-reference
+        String serviceRequestReferenceResult = getServiceRequestReference();
+
+        //ServiceRequest Payment DTO
+        ServiceRequestPaymentDto serviceRequestPaymentDto = ServiceRequestPaymentDto
+            .paymentDtoWith().accountNumber("PBAFUNC12345")
+            .amount(BigDecimal.valueOf(300))
+            .currency("GBP")
+            .idempotencyKey(UUID.randomUUID().toString())
+            .organisationName("sommin")
+            .customerReference("testCustReference").
+            build();
+
+        AccountDto liberataAccountResponse = AccountDto.accountDtoWith()
+            .accountNumber("PBAFUNC12345")
+            .accountName("CAERPHILLY COUNTY BOROUGH COUNCIL")
+            .creditLimit(BigDecimal.valueOf(28879))
+            .availableBalance(BigDecimal.valueOf(30000))
+            .status(AccountStatus.ACTIVE)
+            .build();
+
+        IdempotencyKeys idempotencyKeys = IdempotencyKeys.idempotencyKeysWith()
+            .responseCode(HttpStatus.GATEWAY_TIMEOUT.value())
+            .requestHashcode(-1644540583)
+            .responseStatus(IdempotencyKeys.ResponseStatusType.completed).build();
+
+        List<IdempotencyKeys> gatwayTimeoutKeys = List.of(idempotencyKeys);
+
+        when(idempotencyKeysRepository.findByRequestHashcode(any())).thenReturn(gatwayTimeoutKeys);
+        when(idempotencyKeysRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
+        when(accountService.retrieve("PBAFUNC12345")).thenReturn(liberataAccountResponse);
+
+        ServiceRequestPaymentBo serviceRequestPaymentBo = ServiceRequestPaymentBo.serviceRequestPaymentBoWith().
+            paymentReference("RC-reference").
+            dateCreated("20-09-2021").
+            status("success").
+            build();
+
+        ResponseEntity<ServiceRequestPaymentBo> responseEntity =
+            new ResponseEntity<>(objectMapper.readValue("{\"response_body\":\"response_body\"}", ServiceRequestPaymentBo.class), HttpStatus.CREATED);
+
+        when(serviceRequestDomainService.addPayments(any(),any(),any())).thenReturn(serviceRequestPaymentBo);
+
+        when(serviceRequestDomainService.createIdempotencyRecord(any(),any(),any(),any(),eq(IdempotencyKeys.ResponseStatusType.pending),any(),any())).thenReturn(responseEntity);
+        when(serviceRequestDomainService.createIdempotencyRecord(any(),any(),any(),any(),eq(IdempotencyKeys.ResponseStatusType.completed),any(),any())).thenReturn(responseEntity);
+
+        ServiceRequestResponseDto serviceRequestResponseDtoSample = ServiceRequestResponseDto.serviceRequestResponseDtoWith()
+            .serviceRequestReference("2021-1632746723494").build();
+
+        when(serviceRequestDomainService.create(any(),any())).thenReturn(serviceRequestResponseDtoSample);
+
+        MvcResult successServiceRequestPaymentResult = restActions
+            .post("/service-request/" + serviceRequestReferenceResult + "/pba-payments", serviceRequestPaymentDto)
+            .andExpect(status().isCreated())
             .andReturn();
     }
 
@@ -356,8 +418,8 @@ public class ServiceRequestControllerTest {
             .build();
 
         List<IdempotencyKeys> result = List.of(idempotencyKeys);
-        when(idempotencyService.findTheRecordByRequestHashcode(any())).thenReturn(result);
-        when(idempotencyService.findTheRecordByIdempotencyKey(any())).thenReturn(Optional.of(idempotencyKeys));
+        when(idempotencyKeysRepository.findByRequestHashcode(any())).thenReturn(result);
+        when(idempotencyKeysRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
         when(accountService.retrieve("PBAFUNC12345")).thenReturn(liberataAccountResponse);
 
         ServiceRequestPaymentBo serviceRequestPaymentBo = ServiceRequestPaymentBo.serviceRequestPaymentBoWith().
@@ -422,7 +484,6 @@ public class ServiceRequestControllerTest {
             .build();
 
         IdempotencyKeys idempotencyKeys = IdempotencyKeys.idempotencyKeysWith()
-            .responseCode(HttpStatus.CONFLICT.value())
             .requestHashcode(commonHash)
             .idempotencyKey(UUID.randomUUID().toString())
             .requestBody("")
@@ -430,8 +491,8 @@ public class ServiceRequestControllerTest {
             .build();
 
         List<IdempotencyKeys> result = List.of(idempotencyKeys);
-        when(idempotencyService.findTheRecordByRequestHashcode(any())).thenReturn(result);
-        when(idempotencyService.findTheRecordByIdempotencyKey(any())).thenReturn(Optional.empty());
+        when(idempotencyKeysRepository.findByRequestHashcode(any())).thenReturn(result);
+        when(idempotencyKeysRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
         when(accountService.retrieve("PBAFUNC12345")).thenReturn(liberataAccountResponse);
 
         ServiceRequestPaymentBo serviceRequestPaymentBo = ServiceRequestPaymentBo.serviceRequestPaymentBoWith().
@@ -443,19 +504,13 @@ public class ServiceRequestControllerTest {
         ResponseEntity<ServiceRequestPaymentBo> responseEntityPending =
             new ResponseEntity<>(objectMapper.readValue("{\"response_body\":\"response_body\",\"response_status\":\"pending\"}", ServiceRequestPaymentBo.class), HttpStatus.CREATED);
 
-        ResponseEntity<ServiceRequestPaymentBo> responseEntity =
-            new ResponseEntity<>(objectMapper.readValue("{\"response_body\":\"response_body\"}", ServiceRequestPaymentBo.class), HttpStatus.CREATED);
-
-        ResponseEntity<ServiceRequestPaymentBo> responseEntity2 =
-            new ResponseEntity<>(objectMapper.readValue("{\"response_body\":\"response_body\"}", ServiceRequestPaymentBo.class), HttpStatus.CONFLICT);
-
-        ResponseEntity<ServiceRequestPaymentBo> responseEntity3 =
-            new ResponseEntity<>(objectMapper.readValue("{\"response_body\":\"response_body\"}", ServiceRequestPaymentBo.class), HttpStatus.PRECONDITION_FAILED);
+        ResponseEntity<ServiceRequestPaymentBo> responseEntityCompleted =
+            new ResponseEntity<>(objectMapper.readValue("{\"response_body\":\"response_body\",\"response_status\":\"completed\"}}", ServiceRequestPaymentBo.class), HttpStatus.CREATED);
 
         when(serviceRequestDomainService.addPayments(any(),any(),any())).thenReturn(serviceRequestPaymentBo);
 
-        when(serviceRequestDomainService.createIdempotencyRecord(any(),any(),any(),any(),eq(IdempotencyKeys.ResponseStatusType.pending),any(),any())).thenReturn(responseEntityPending,responseEntityPending, responseEntityPending, responseEntityPending);
-        when(serviceRequestDomainService.createIdempotencyRecord(any(),any(),any(),any(),eq(IdempotencyKeys.ResponseStatusType.completed),any(),any())).thenReturn(responseEntity,responseEntity,responseEntity2,responseEntity3);
+        when(serviceRequestDomainService.createIdempotencyRecord(any(),any(),any(),any(),eq(IdempotencyKeys.ResponseStatusType.pending),any(),any())).thenReturn(responseEntityPending);
+        when(serviceRequestDomainService.createIdempotencyRecord(any(),any(),any(),any(),eq(IdempotencyKeys.ResponseStatusType.completed),any(),any())).thenReturn(responseEntityCompleted);
 
         ServiceRequestResponseDto serviceRequestResponseDtoSample = ServiceRequestResponseDto.serviceRequestResponseDtoWith()
             .serviceRequestReference("2021-1632746723494").build();
@@ -466,6 +521,8 @@ public class ServiceRequestControllerTest {
             .post("/service-request/" + serviceRequestReferenceResult + "/pba-payments", serviceRequestPaymentDto)
             .andExpect(status().isConflict())
             .andReturn();
+
+        var s = "test";
     }
 
     @Test

--- a/api/src/test/java/uk/gov/hmcts/payment/api/domain/service/IdempotencyServiceImplTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/domain/service/IdempotencyServiceImplTest.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.payment.api.domain.service;
 
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-
 
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -15,7 +13,9 @@ import uk.gov.hmcts.payment.api.model.IdempotencyKeysRepository;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -38,18 +38,59 @@ public class IdempotencyServiceImplTest {
         when(idempotencyKeysRepository.findByIdempotencyKey(any())).thenReturn(Optional.of(idempotencyKeys));
 
         var response = idempotencyServiceImpl.findTheRecordByIdempotencyKey("test");
-        assertThat(response).isNotNull();
+        assertNotNull(response);
     }
 
     @Test
     public void findTheRecordByRequestHashcode() {
 
-        IdempotencyKeys idempotencyKeys = IdempotencyKeys.idempotencyKeysWith().responseCode(HttpStatus.CONFLICT.value()).requestHashcode(-1644540583).idempotencyKey("").requestBody("").build();
+        IdempotencyKeys idempotencyKeys = IdempotencyKeys.idempotencyKeysWith().responseCode(HttpStatus.CONFLICT.value()).
+            requestHashcode(-1644540583).idempotencyKey("").requestBody("").responseStatus(IdempotencyKeys.ResponseStatusType.pending).build();
+
         List<IdempotencyKeys> result = List.of(idempotencyKeys);
 
         when(idempotencyKeysRepository.findByRequestHashcode(any())).thenReturn(result);
 
-        var response = idempotencyServiceImpl.findTheRecordByRequestHashcode(3333);
-        assertThat(response).isNotNull();
+        List<IdempotencyKeys> response = idempotencyServiceImpl.findTheRecordByRequestHashcode(3333);
+        assertNotNull(response);
+        assertEquals(1, response.size());
+    }
+
+    @Test
+    public void findTheRecordByRequestHashcodeWithAnEmptyList() {
+
+        List<IdempotencyKeys> result = List.of();
+
+        when(idempotencyKeysRepository.findByRequestHashcode(any())).thenReturn(result);
+
+        List<IdempotencyKeys> response = idempotencyServiceImpl.findTheRecordByRequestHashcode(3333);
+        assertNotNull(response);
+        assertEquals(0, response.size());
+    }
+
+    @Test
+    public void findTheRecordByRequestHashcodeWithFilteredResults() {
+
+        IdempotencyKeys idempotencyKeys1 = IdempotencyKeys.idempotencyKeysWith().responseCode(HttpStatus.GATEWAY_TIMEOUT.value()).
+            requestHashcode(-1644540583).idempotencyKey("idempKey01").requestBody("").responseStatus(IdempotencyKeys.ResponseStatusType.completed).build();
+
+        IdempotencyKeys idempotencyKeys2 = IdempotencyKeys.idempotencyKeysWith().
+            requestHashcode(-1644540583).idempotencyKey("idempKey02").requestBody("").responseStatus(IdempotencyKeys.ResponseStatusType.pending).build();
+
+        IdempotencyKeys idempotencyKeys3 = IdempotencyKeys.idempotencyKeysWith().responseCode(HttpStatus.PAYMENT_REQUIRED.value()).
+            requestHashcode(-1644540583).idempotencyKey("idempKey03").requestBody("").responseStatus(IdempotencyKeys.ResponseStatusType.completed).build();
+
+        IdempotencyKeys idempotencyKeys4 = IdempotencyKeys.idempotencyKeysWith().responseCode(HttpStatus.CONFLICT.value()).
+            requestHashcode(-1644540583).idempotencyKey("idempKey04").requestBody("").responseStatus(IdempotencyKeys.ResponseStatusType.completed).build();
+
+        List<IdempotencyKeys> results = List.of(idempotencyKeys1, idempotencyKeys2, idempotencyKeys3, idempotencyKeys4);
+
+        when(idempotencyKeysRepository.findByRequestHashcode(any())).thenReturn(results);
+
+        List<IdempotencyKeys> response = idempotencyServiceImpl.findTheRecordByRequestHashcode(3333);
+        assertNotNull(response);
+        assertEquals(2, response.size());
+        assertEquals("idempKey02", response.get(0).getIdempotencyKey());
+        assertEquals("idempKey04", response.get(1).getIdempotencyKey());
     }
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-6779


### Change description ###
Allow retry on failed liberata calls, specifically responses which come back as HTTP 504, 412 and 402.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
