### PR TITLE
PAY-2787: Pass language to GovPay

### DIFF
--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/mapper/ServiceRequestDtoDomainMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/mapper/ServiceRequestDtoDomainMapper.java
@@ -82,11 +82,12 @@ public class ServiceRequestDtoDomainMapper {
     }
 
     public CreatePaymentRequest createGovPayRequest(ServiceRequestOnlinePaymentBo requestOnlinePaymentBo) {
-        LOG.info("requestOnlinePaymentBo.getLanguage() {}",requestOnlinePaymentBo.getLanguage());
+        String reqPaymentLanguage = (requestOnlinePaymentBo.getLanguage() != null
+            && requestOnlinePaymentBo.getLanguage().equalsIgnoreCase("cy")) ? "cy" : "en";
+        LOG.info("requestOnlinePaymentBo.getLanguage() {} -> {}", requestOnlinePaymentBo.getLanguage(), reqPaymentLanguage);
         return new CreatePaymentRequest(requestOnlinePaymentBo.getAmount().movePointRight(2).intValue(),
             requestOnlinePaymentBo.getPaymentReference(), requestOnlinePaymentBo.getDescription(),
-            requestOnlinePaymentBo.getReturnUrl(),
-         null
+            requestOnlinePaymentBo.getReturnUrl(), reqPaymentLanguage
         );
     }
 }

--- a/api/src/test/java/uk/gov/hmcts/payment/api/mapper/ServiceRequestDtoDomainMapperTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/mapper/ServiceRequestDtoDomainMapperTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.payment.api.dto.OnlineCardPaymentRequest;
 import uk.gov.hmcts.payment.api.dto.OrganisationalServiceDto;
 import uk.gov.hmcts.payment.api.dto.servicerequest.ServiceRequestDto;
 import uk.gov.hmcts.payment.api.dto.servicerequest.ServiceRequestFeeDto;
+import uk.gov.hmcts.payment.api.external.client.dto.CreatePaymentRequest;
 import uk.gov.hmcts.payment.api.util.ReferenceUtil;
 import uk.gov.hmcts.payment.api.v1.model.ServiceIdSupplier;
 import uk.gov.hmcts.payment.api.v1.model.UserIdSupplier;
@@ -88,13 +89,75 @@ public class ServiceRequestDtoDomainMapperTest {
             .amount(new BigDecimal(99.99))
             .description("desc")
             .returnUrl("http://returnUrl")
-            .language("Eng")
+            .language("en")
             .paymentReference("RC-ref")
             .build();
 
-        serviceRequestDtoDomainMapper.createGovPayRequest(serviceRequestOnlinePaymentBo);
+        CreatePaymentRequest govPayRequest = serviceRequestDtoDomainMapper.createGovPayRequest(serviceRequestOnlinePaymentBo);
 
-        assertThat(serviceRequestDtoDomainMapper.createGovPayRequest(serviceRequestOnlinePaymentBo).getClass().getName().equals("CreatePaymentRequest"));
+        assertThat(govPayRequest.getDescription().equals("desc"));
+        assertThat(govPayRequest.getReference().equals("RC-ref"));
+        assertThat(govPayRequest.getReturnUrl().equals("http://returnUrl"));
+        assertThat(govPayRequest.getAmount().equals(99));
+        assertThat(govPayRequest.getLanguage().equals("en"));
+
+    }
+
+    @Test
+    public void createGovPayRequestWelshanguageTest() {
+
+        ServiceRequestOnlinePaymentBo serviceRequestOnlinePaymentBo = ServiceRequestOnlinePaymentBo.serviceRequestOnlinePaymentBo()
+            .amount(new BigDecimal(99.99))
+            .description("desc")
+            .returnUrl("http://returnUrl")
+            .language("cy")
+            .paymentReference("RC-ref")
+            .build();
+
+        CreatePaymentRequest govPayRequest = serviceRequestDtoDomainMapper.createGovPayRequest(serviceRequestOnlinePaymentBo);
+
+        assertThat(govPayRequest.getDescription().equals("desc"));
+        assertThat(govPayRequest.getReference().equals("RC-ref"));
+        assertThat(govPayRequest.getReturnUrl().equals("http://returnUrl"));
+        assertThat(govPayRequest.getAmount().equals(99));
+        assertThat(govPayRequest.getLanguage().equals("cy"));
+
+    }
+
+    @Test
+    public void createGovPayRequestWithEnglishDefaultLanguageTest() {
+
+        ServiceRequestOnlinePaymentBo serviceRequestOnlinePaymentBo = ServiceRequestOnlinePaymentBo.serviceRequestOnlinePaymentBo()
+            .amount(new BigDecimal(99.99))
+            .description("desc")
+            .returnUrl("http://returnUrl")
+            .paymentReference("RC-ref")
+            .build();
+
+        // Language null
+        serviceRequestOnlinePaymentBo.setLanguage(null);
+        CreatePaymentRequest govPayRequest = serviceRequestDtoDomainMapper.createGovPayRequest(serviceRequestOnlinePaymentBo);
+        assertThat(govPayRequest.getLanguage().equals("en"));
+
+        // Language '' (empty)
+        serviceRequestOnlinePaymentBo.setLanguage("");
+        govPayRequest = serviceRequestDtoDomainMapper.createGovPayRequest(serviceRequestOnlinePaymentBo);
+        assertThat(govPayRequest.getLanguage().equals("en"));
+
+        // Language 'string'
+        serviceRequestOnlinePaymentBo.setLanguage("string");
+        govPayRequest = serviceRequestDtoDomainMapper.createGovPayRequest(serviceRequestOnlinePaymentBo);
+        assertThat(govPayRequest.getLanguage().equals("en"));
+
+        // Language 'EN'
+        serviceRequestOnlinePaymentBo.setLanguage("EN");
+        govPayRequest = serviceRequestDtoDomainMapper.createGovPayRequest(serviceRequestOnlinePaymentBo);
+        assertThat(govPayRequest.getLanguage().equals("en"));
+
+        // Language 'English'
+        serviceRequestOnlinePaymentBo.setLanguage("English!");
+        govPayRequest = serviceRequestDtoDomainMapper.createGovPayRequest(serviceRequestOnlinePaymentBo);
+        assertThat(govPayRequest.getLanguage().equals("en"));
 
     }
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-2787


### Change description ###
Ensures the language 'en' or 'cy' is passed to GovPay. Language will always default to 'en' unless 'cy' is passed.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
