### PR TITLE
PAY-6943: Change to pull back card payment based on reference

### DIFF
--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java
@@ -194,7 +194,7 @@ public class CardPaymentController implements ApplicationContextAware {
     })
     @GetMapping(value = "/card-payments/{reference}")
     public PaymentDto retrieve(@PathVariable("reference") String paymentReference) {
-        return paymentDtoMapper.toRetrieveCardPaymentResponseDto(delegatingPaymentService.retrieve(paymentReference));
+        return paymentDtoMapper.toRetrieveCardPaymentResponseDto(delegatingPaymentService.retrieve(paymentReference), paymentReference);
     }
 
     @Operation(summary = "Get card payment details with card details by payment reference", description = "Get payment details with card details for supplied payment reference")

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
@@ -133,7 +133,23 @@ public class PaymentDtoMapper {
     }
 
     public PaymentDto toRetrieveCardPaymentResponseDto(PaymentFeeLink paymentFeeLink, String paymentReference) {
-        Payment payment = paymentFeeLink.getPayments().get(0);
+        LOG.info("paymentFeeLink.getPayments() {}",paymentFeeLink.getPayments());
+        LOG.info("Getting Payment with reference: {}", paymentReference);
+        Optional<Payment> optionalPayment = paymentFeeLink.getPayments().stream()
+            .filter(payment -> (paymentReference != null)
+                && paymentReference.equalsIgnoreCase(payment.getReference()))
+            .findFirst();
+        Payment payment;
+        if(optionalPayment.isEmpty()){
+            LOG.info("Payment not found for reference: {}", paymentReference);
+            throw new PaymentNotFoundException("The reference is not found");
+        } else {
+            payment = optionalPayment.get();
+            LOG.info("Payment found for reference: {}", paymentReference);
+        }
+        LOG.info("reference: {} for the payment returned", payment.getReference());
+        LOG.info("payment status from gov uk - {}",payment.getPaymentStatus().getName());
+        LOG.info("payment status from gov uk enum mapping - {}",PayStatusToPayHubStatus.valueOf(payment.getPaymentStatus().getName()).getMappedStatus());
         List<PaymentFee> fees = paymentFeeLink.getFees();
         return PaymentDto.payment2DtoWith()
             .reference(payment.getReference())

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
@@ -84,10 +84,6 @@ public class PaymentDtoMapper {
             .build();
     }
 
-
-
-
-
     public PaymentDto toPciPalCardPaymentDto(PaymentFeeLink paymentFeeLink, String link) {
         Payment payment = paymentFeeLink.getPayments().get(0);
         return PaymentDto.payment2DtoWith()
@@ -136,7 +132,7 @@ public class PaymentDtoMapper {
             .build();
     }
 
-    public PaymentDto toRetrieveCardPaymentResponseDto(PaymentFeeLink paymentFeeLink) {
+    public PaymentDto toRetrieveCardPaymentResponseDto(PaymentFeeLink paymentFeeLink, String paymentReference) {
         Payment payment = paymentFeeLink.getPayments().get(0);
         List<PaymentFee> fees = paymentFeeLink.getFees();
         return PaymentDto.payment2DtoWith()
@@ -163,8 +159,24 @@ public class PaymentDtoMapper {
             .build();
     }
 
-    public PaymentDto toRetrievePaymentStatusesDto(PaymentFeeLink paymentFeeLink) {
-        Payment payment = paymentFeeLink.getPayments().get(0);
+    public PaymentDto toRetrievePaymentStatusesDto(PaymentFeeLink paymentFeeLink, String paymentReference) {
+        LOG.info("paymentFeeLink.getPayments() {}",paymentFeeLink.getPayments());
+        LOG.info("Getting Payment with reference: {}", paymentReference);
+        Optional<Payment> optionalPayment = paymentFeeLink.getPayments().stream()
+            .filter(payment -> (paymentReference != null)
+                && paymentReference.equalsIgnoreCase(payment.getReference()))
+            .findFirst();
+        Payment payment;
+        if(optionalPayment.isEmpty()){
+            LOG.info("Payment not found for reference: {}", paymentReference);
+            throw new PaymentNotFoundException("The reference is not found");
+        } else {
+            payment = optionalPayment.get();
+            LOG.info("Payment found for reference: {}", paymentReference);
+        }
+        LOG.info("reference: {} for the payment returned", payment.getReference());
+        LOG.info("payment status from gov uk - {}",payment.getPaymentStatus().getName());
+        LOG.info("payment status from gov uk enum mapping - {}",PayStatusToPayHubStatus.valueOf(payment.getPaymentStatus().getName()).getMappedStatus());
         return PaymentDto.payment2DtoWith()
             .reference(payment.getReference())
             .amount(payment.getAmount())

--- a/api/src/test/java/uk/gov/hmcts/payment/api/mapper/PaymentDtoMapperTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/mapper/PaymentDtoMapperTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.payment.api.contract.PaymentDto;
 import uk.gov.hmcts.payment.api.dto.mapper.PaymentDtoMapper;
 import uk.gov.hmcts.payment.api.model.*;
 import uk.gov.hmcts.payment.api.reports.FeesService;
+import uk.gov.hmcts.payment.api.v1.model.exceptions.PaymentNotFoundException;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -38,9 +40,9 @@ public class PaymentDtoMapperTest {
     @InjectMocks
     PaymentDtoMapper paymentDtoMapper = new PaymentDtoMapper();
 
-    PaymentFeeLink paymentFeeLink;
+    PaymentFeeLink paymentFeeLink, paymentFeeLinkMultiplePayments;
 
-    Payment payment1;
+    Payment payment1, multiplePayment1, multiplePayment2;
 
     List<PaymentFee> paymentFees;
 
@@ -49,6 +51,7 @@ public class PaymentDtoMapperTest {
     @Before
     public void initiate(){
         List<Payment> payments = new ArrayList<Payment>();
+        List<Payment> multiplePayments = new ArrayList<Payment>();
         List<PaymentAllocation> paymentAllocations1 = new ArrayList<PaymentAllocation>();
         allocation1 = PaymentAllocation.paymentAllocationWith()
             .receivingOffice("receiving-office")
@@ -94,13 +97,58 @@ public class PaymentDtoMapperTest {
             .currency("GBP")
             .statusHistories(statusHistories)
             .id(1).build();
+        multiplePayment1 = Payment.paymentWith()
+            .siteId("siteId")
+            .paymentChannel(PaymentChannel.paymentChannelWith().name("bulk scan").build())
+            .serviceType("service-type")
+            .caseReference("case-reference")
+            .reference("RC-1612-3710-5335-6484")
+            .ccdCaseNumber("ccd-case-number")
+            .status("success")
+            .bankedDate(new Date(2021,1,1))
+            .documentControlNumber("document-control-number")
+            .paymentMethod(PaymentMethod.paymentMethodWith().name("pay-method").build())
+            .amount(new BigDecimal("100.00"))
+            .paymentStatus(PaymentStatus.SUCCESS)
+            .dateCreated(new Date(2020,10,1))
+            .paymentAllocation(paymentAllocations1)
+            .currency("GBP")
+            .statusHistories(statusHistories)
+            .id(2).build();
+        multiplePayment2 = Payment.paymentWith()
+            .siteId("siteId")
+            .paymentChannel(PaymentChannel.paymentChannelWith().name("bulk scan").build())
+            .serviceType("service-type")
+            .caseReference("case-reference")
+            .reference("RC-1612-3710-5335-6490")
+            .ccdCaseNumber("ccd-case-number")
+            .status("success")
+            .bankedDate(new Date(2021,1,1))
+            .documentControlNumber("document-control-number")
+            .paymentMethod(PaymentMethod.paymentMethodWith().name("pay-method").build())
+            .amount(new BigDecimal("100.00"))
+            .paymentStatus(PaymentStatus.FAILED)
+            .dateCreated(new Date(2020,10,1))
+            .paymentAllocation(paymentAllocations1)
+            .currency("GBP")
+            .statusHistories(statusHistories)
+            .id(3).build();
         payments.add(payment1);
+        multiplePayments.add(multiplePayment1);
+        multiplePayments.add(multiplePayment2);
         paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith()
                             .paymentReference("group-reference")
                             .dateCreated(new Date(2021,1,1))
                             .fees(paymentFees)
                             .payments(payments).build();
+        paymentFeeLinkMultiplePayments = PaymentFeeLink.paymentFeeLinkWith()
+            .paymentReference("group-reference")
+            .dateCreated(new Date(2021,1,1))
+            .fees(paymentFees)
+            .payments(multiplePayments).build();
         payment1.setPaymentLink(paymentFeeLink);
+        multiplePayment1.setPaymentLink(paymentFeeLinkMultiplePayments);
+        multiplePayment2.setPaymentLink(paymentFeeLinkMultiplePayments);
     }
 
     @Test
@@ -142,14 +190,64 @@ public class PaymentDtoMapperTest {
     public void testToRetrieveCardPaymentResponseDto(){
         PaymentDto paymentDto = paymentDtoMapper.toRetrieveCardPaymentResponseDto(paymentFeeLink, payment1.getReference());
         assertEquals("group-reference",paymentDto.getPaymentGroupReference());
+        assertTrue(PaymentStatus.SUCCESS.getName().equalsIgnoreCase(paymentDto.getStatus()));
+        assertEquals("RC-1612-3710-5335-6484",paymentDto.getReference());
         assertEquals("service-type",paymentDto.getServiceName());
+    }
+
+    @Test
+    public void testToRetrieveCardPaymentResponseDtoMultipleReferences1(){
+        PaymentDto paymentDto = paymentDtoMapper.toRetrieveCardPaymentResponseDto(paymentFeeLinkMultiplePayments, multiplePayment1.getReference());
+        assertEquals("group-reference",paymentDto.getPaymentGroupReference());
+        assertTrue(PaymentStatus.SUCCESS.getName().equalsIgnoreCase(paymentDto.getStatus()));
+        assertEquals("RC-1612-3710-5335-6484",paymentDto.getReference());
+        assertEquals("service-type",paymentDto.getServiceName());
+    }
+
+    @Test
+    public void testToRetrieveCardPaymentResponseDtoMultipleReferences2(){
+        PaymentDto paymentDto = paymentDtoMapper.toRetrieveCardPaymentResponseDto(paymentFeeLinkMultiplePayments, multiplePayment2.getReference());
+        assertEquals("group-reference",paymentDto.getPaymentGroupReference());
+        assertTrue(PaymentStatus.FAILED.getName().equalsIgnoreCase(paymentDto.getStatus()));
+        assertEquals("RC-1612-3710-5335-6490",paymentDto.getReference());
+        assertEquals("service-type",paymentDto.getServiceName());
+    }
+
+    @Test(expected = PaymentNotFoundException.class)
+    public void testToRetrieveCardPaymentResponseDtoMissingReference(){
+        PaymentDto paymentDto = paymentDtoMapper.toRetrieveCardPaymentResponseDto(paymentFeeLink, "RC-0000-0000-0000-0000");
     }
 
     @Test
     public void testToRetrievePaymentStatusesDto(){
         PaymentDto paymentDto = paymentDtoMapper.toRetrievePaymentStatusesDto(paymentFeeLink, payment1.getReference());
         assertEquals("group-reference",paymentDto.getPaymentGroupReference());
+        assertTrue(PaymentStatus.SUCCESS.getName().equalsIgnoreCase(paymentDto.getStatus()));
+        assertEquals("RC-1612-3710-5335-6484",paymentDto.getReference());
         assertEquals("100.00",paymentDto.getAmount().toString());
+    }
+
+    @Test
+    public void testToRetrievePaymentStatusesDtoMultipleReferences1(){
+        PaymentDto paymentDto = paymentDtoMapper.toRetrievePaymentStatusesDto(paymentFeeLinkMultiplePayments, multiplePayment1.getReference());
+        assertEquals("group-reference",paymentDto.getPaymentGroupReference());
+        assertTrue(PaymentStatus.SUCCESS.getName().equalsIgnoreCase(paymentDto.getStatus()));
+        assertEquals("RC-1612-3710-5335-6484",paymentDto.getReference());
+        assertEquals("100.00",paymentDto.getAmount().toString());
+    }
+
+    @Test
+    public void testToRetrievePaymentStatusesDtoMultipleReferences2(){
+        PaymentDto paymentDto = paymentDtoMapper.toRetrievePaymentStatusesDto(paymentFeeLinkMultiplePayments, multiplePayment2.getReference());
+        assertEquals("group-reference",paymentDto.getPaymentGroupReference());
+        assertTrue(PaymentStatus.FAILED.getName().equalsIgnoreCase(paymentDto.getStatus()));
+        assertEquals("RC-1612-3710-5335-6490",paymentDto.getReference());
+        assertEquals("100.00",paymentDto.getAmount().toString());
+    }
+
+    @Test(expected = PaymentNotFoundException.class)
+    public void testToRetrievePaymentStatusesDtoMissingReference(){
+        PaymentDto paymentDto = paymentDtoMapper.toRetrievePaymentStatusesDto(paymentFeeLink, "RC-0000-0000-0000-0000");
     }
 
     @Test

--- a/api/src/test/java/uk/gov/hmcts/payment/api/mapper/PaymentDtoMapperTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/mapper/PaymentDtoMapperTest.java
@@ -140,14 +140,14 @@ public class PaymentDtoMapperTest {
 
     @Test
     public void testToRetrieveCardPaymentResponseDto(){
-        PaymentDto paymentDto = paymentDtoMapper.toRetrieveCardPaymentResponseDto(paymentFeeLink);
+        PaymentDto paymentDto = paymentDtoMapper.toRetrieveCardPaymentResponseDto(paymentFeeLink, payment1.getReference());
         assertEquals("group-reference",paymentDto.getPaymentGroupReference());
         assertEquals("service-type",paymentDto.getServiceName());
     }
 
     @Test
     public void testToRetrievePaymentStatusesDto(){
-        PaymentDto paymentDto = paymentDtoMapper.toRetrievePaymentStatusesDto(paymentFeeLink);
+        PaymentDto paymentDto = paymentDtoMapper.toRetrievePaymentStatusesDto(paymentFeeLink, payment1.getReference());
         assertEquals("group-reference",paymentDto.getPaymentGroupReference());
         assertEquals("100.00",paymentDto.getAmount().toString());
     }

--- a/api/src/test/java/uk/gov/hmcts/payment/api/unit/SendMessageApplication.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/unit/SendMessageApplication.java
@@ -20,15 +20,17 @@ public class SendMessageApplication {
 
         TopicClientProxy client = new TopicClientProxy("<Service-bus Connection String>", "serviceCallbackTopic");
 
+        String paymentReference = "00000005";
+
         Payment payment = CardPaymentComponentTest.getPaymentsData().get(2);
 
-        PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().paymentReference("00000005")
+        PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().paymentReference(paymentReference)
             .payments(Arrays.asList(payment))
             .fees(PaymentsDataUtil.getFeesData())
             .build();
 
         PaymentDto dto = new PaymentDtoMapper()
-            .toRetrievePaymentStatusesDto(paymentFeeLink);
+            .toRetrievePaymentStatusesDto(paymentFeeLink, paymentReference);
 
         Message msg = new Message(new ObjectMapper().writeValueAsString(dto));
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-6943


### Change description ###
Update to the /card-payments/{reference} endpoint to also use the reference ("RC" number) when determining the payments from the payment_link_id value which isn't unique if there are multiple payment attempts.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
