### PR TITLE
PAY-7137: Make Payment Reference -Unique

### DIFF
--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/PayFeeLinkRepositoryStub.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/PayFeeLinkRepositoryStub.java
@@ -131,4 +131,9 @@ public class PayFeeLinkRepositoryStub implements PaymentFeeLinkRepository {
     public boolean exists(Specification<PaymentFeeLink> spec) {
         return false;
     }
+
+    @Override
+    public String getNextPaymentReference() {
+        return "2021-0000000001";
+    }
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java
@@ -87,6 +87,9 @@ public class CardPaymentController implements ApplicationContextAware {
     private ApplicationContext applicationContext;
 
     @Autowired
+    private PaymentReference paymentReference;
+
+    @Autowired
     public CardPaymentController(DelegatingPaymentService<PaymentFeeLink, String> cardDelegatingPaymentService,
                                  PaymentDtoMapper paymentDtoMapper,
                                  CardDetailsService<CardDetails, String> cardDetailsService,
@@ -118,7 +121,7 @@ public class CardPaymentController implements ApplicationContextAware {
         @RequestHeader(value = "service-callback-url", required = false) String serviceCallbackUrl,
         @RequestHeader(required = false) MultiValueMap<String, String> headers,
         @Valid @RequestBody CardPaymentRequest request) throws CheckDigitException {
-        String paymentGroupReference = PaymentReference.getInstance().getNext();
+        String paymentGroupReference = paymentReference.getNext();
 
         if (StringUtils.isEmpty(request.getChannel()) || StringUtils.isEmpty(request.getProvider())) {
             request.setChannel("online");

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CreditAccountPaymentController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CreditAccountPaymentController.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.checkdigit.CheckDigitException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -65,6 +66,9 @@ public class CreditAccountPaymentController {
     private final ReferenceDataService referenceDataService;
     private final AuthTokenGenerator authTokenGenerator;
 
+    @Autowired
+    PaymentReference paymentReference;
+
     public CreditAccountPaymentController(
         @Qualifier("loggingCreditAccountPaymentService") CreditAccountPaymentService<PaymentFeeLink, String> creditAccountPaymentService,
         CreditAccountDtoMapper creditAccountDtoMapper,
@@ -102,7 +106,7 @@ public class CreditAccountPaymentController {
     @ResponseBody
     @Transactional
     public ResponseEntity<PaymentDto> createCreditAccountPayment(@Valid @RequestBody CreditAccountPaymentRequest creditAccountPaymentRequest, @RequestHeader(required = false) MultiValueMap<String, String> headers) throws CheckDigitException {
-        String paymentGroupReference = PaymentReference.getInstance().getNext();
+        String paymentGroupReference = paymentReference.getNext();
 
         /*
         Following piece of code to be removed once all Services are on-boarded to PBA Config 2

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentGroupController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentGroupController.java
@@ -119,6 +119,9 @@ public class PaymentGroupController {
     private PaymentService<PaymentFeeLink, String> paymentService;
 
     @Autowired
+    private PaymentReference paymentReference;
+
+    @Autowired
     public PaymentGroupController(PaymentGroupService paymentGroupService, PaymentGroupDtoMapper paymentGroupDtoMapper,
                                   DelegatingPaymentService<PaymentFeeLink, String> delegatingPaymentService,
                                   PaymentDtoMapper paymentDtoMapper, PciPalPaymentService pciPalPaymentService,
@@ -164,7 +167,7 @@ public class PaymentGroupController {
     @PostMapping(value = "/payment-groups")
     public ResponseEntity<PaymentGroupDto> addNewFee(@Valid @RequestBody PaymentGroupDto paymentGroupDto) {
 
-        String paymentGroupReference = PaymentReference.getInstance().getNext();
+        String paymentGroupReference = paymentReference.getNext();
 
         paymentGroupDto.getFees().stream().forEach(f -> {
             if (f.getCcdCaseNumber() == null && f.getReference() == null) {
@@ -284,7 +287,7 @@ public class PaymentGroupController {
 
         List<SiteDTO> sites = referenceDataService.getSiteIDs();
 
-        String paymentGroupReference = PaymentReference.getInstance().getNext();
+        String paymentGroupReference = paymentReference.getNext();
 
         if (!sites.stream().anyMatch(site -> site.getSiteID().equalsIgnoreCase(bulkScanPaymentRequest.getSiteId()))) {
             throw new PaymentException("Invalid siteID: " + bulkScanPaymentRequest.getSiteId());
@@ -421,7 +424,7 @@ public class PaymentGroupController {
                 }
             }
 
-            String paymentGroupReference = PaymentReference.getInstance().getNext();
+            String paymentGroupReference = paymentReference.getNext();
 
             OrganisationalServiceDto organisationalServiceDto = referenceDataService.getOrganisationalDetail(Optional.ofNullable(bulkScanPaymentRequestStrategic.getCaseType()),Optional.empty(), headers);
 

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentRecordController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentRecordController.java
@@ -56,6 +56,9 @@ public class PaymentRecordController {
     private PaymentService<PaymentFeeLink, String> paymentService;
 
     @Autowired
+    private PaymentReference paymentReference;
+
+    @Autowired
     public PaymentRecordController(PaymentRecordService<PaymentFeeLink, String> paymentRecordService,
                                    PaymentDtoMapper paymentDtoMapper,
                                    PaymentProviderRepository paymentProviderRespository,
@@ -76,7 +79,7 @@ public class PaymentRecordController {
     @RequestMapping(value = "/payment-records", method = POST)
     @ResponseBody
     public ResponseEntity<PaymentDto> recordPayment(@Valid @RequestBody PaymentRecordRequest paymentRecordRequest) throws CheckDigitException {
-        String paymentGroupReference = PaymentReference.getInstance().getNext();
+        String paymentGroupReference = paymentReference.getNext();
 
         List<SiteDTO> sites = referenceDataService.getSiteIDs();
 

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentReference.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentReference.java
@@ -1,14 +1,25 @@
 package uk.gov.hmcts.payment.api.controllers;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.payment.api.model.PaymentFeeLinkRepository;
 
-import java.security.SecureRandom;
-import java.time.LocalDateTime;
+import javax.annotation.PostConstruct;
 
+@Component
 public class PaymentReference {
 
+    @Autowired
+    private PaymentFeeLinkRepository paymentFeeLinkRepositoryInstance;
+
+    private static PaymentFeeLinkRepository paymentFeeLinkRepository;
+
     private static PaymentReference obj = null;
+
+    @PostConstruct
+    private void init() {
+        paymentFeeLinkRepository = paymentFeeLinkRepositoryInstance;
+    }
 
     private PaymentReference() {
     }
@@ -22,13 +33,7 @@ public class PaymentReference {
     }
 
     public String getNext() {
-        SecureRandom random = new SecureRandom();
-
-        DateTime dateTime = new DateTime(DateTimeZone.UTC);
-        long dateTimeinMillis = dateTime.getMillis() / 100;
-
-        String nextVal = String.format("%010d", dateTimeinMillis);
-        return LocalDateTime.now().getYear() + "-" + nextVal + + (random.nextInt(89)+10);
+        return paymentFeeLinkRepository.getNextPaymentReference();
     }
 
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentReference.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentReference.java
@@ -4,33 +4,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.payment.api.model.PaymentFeeLinkRepository;
 
-import javax.annotation.PostConstruct;
-
 @Component
 public class PaymentReference {
 
     @Autowired
-    private PaymentFeeLinkRepository paymentFeeLinkRepositoryInstance;
-
-    private static PaymentFeeLinkRepository paymentFeeLinkRepository;
-
-    private static PaymentReference obj = null;
-
-    @PostConstruct
-    private void init() {
-        paymentFeeLinkRepository = paymentFeeLinkRepositoryInstance;
-    }
-
-    private PaymentReference() {
-    }
-
-    public static PaymentReference getInstance() {
-        if (obj == null) {
-            obj = new PaymentReference();
-        }
-
-        return obj;
-    }
+    private PaymentFeeLinkRepository paymentFeeLinkRepository;
 
     public String getNext() {
         return paymentFeeLinkRepository.getNextPaymentReference();

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/RemissionController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/RemissionController.java
@@ -41,6 +41,9 @@ public class RemissionController {
     @Autowired
     private ReferenceDataService referenceDataService;
 
+    @Autowired
+    private PaymentReference paymentReference;
+
     @Operation(summary = "Create upfront remission record", description = "Create upfront remission record")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "Remission created"),
@@ -111,7 +114,7 @@ public class RemissionController {
 
     private RemissionServiceRequest populateRemissionServiceRequest(RemissionRequest remissionRequest, OrganisationalServiceDto organisationalServiceDto) {
         return RemissionServiceRequest.remissionServiceRequestWith()
-            .paymentGroupReference(PaymentReference.getInstance().getNext())
+            .paymentGroupReference(paymentReference.getNext())
             .hwfAmount(remissionRequest.getHwfAmount())
             .hwfReference(remissionRequest.getHwfReference())
             .beneficiaryName(remissionRequest.getBeneficiaryName())

--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/mapper/ServiceRequestDtoDomainMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/mapper/ServiceRequestDtoDomainMapper.java
@@ -34,12 +34,14 @@ public class ServiceRequestDtoDomainMapper {
     private UserIdSupplier userIdSupplier;
     @Autowired
     private ServiceIdSupplier serviceIdSupplier;
+    @Autowired
+    private PaymentReference paymentReference;
 
     private static final Logger LOG = LoggerFactory.getLogger(ServiceRequestDtoDomainMapper.class);
 
     public ServiceRequestBo toDomain(ServiceRequestDto serviceRequestDto, OrganisationalServiceDto organisationalServiceDto) {
 
-        String serviceRequestReference = PaymentReference.getInstance().getNext();
+        String serviceRequestReference = paymentReference.getNext();
 
         return ServiceRequestBo.serviceRequestBoWith()
             .callBackUrl(serviceRequestDto.getCallBackUrl())

--- a/api/src/main/resources/application-local.properties
+++ b/api/src/main/resources/application-local.properties
@@ -1,7 +1,7 @@
 spring.application.name=payment
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
-spring.datasource.url=jdbc:postgresql://localhost:5430/payment
-spring.datasource.username=payment
+spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5430}/${POSTGRES_NAME:payment}${POSTGRES_CONNECTION_OPTIONS:}
+spring.datasource.username=${POSTGRES_USERNAME:payment}
 spring.datasource.password=${POSTGRES_PASSWORD:}
 spring.datasource.driver=org.postgresql.Driver
 spring.autoconfigure.exclude=uk.gov.hmcts.reform.ccd.client.CoreCaseDataClientAutoConfiguration
@@ -77,6 +77,8 @@ spring.mail.host=${SPRING_MAIL_HOST:mta.reform.hmcts.net}
 spring.mail.port=${SPRING_MAIL_PORT:25}
 spring.mail.properties.mail.smtp.starttls.enable=${SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE:true}
 spring.mail.properties.mail.smtp.ssl.trust=${EMAIL_SMTP_SSL_TRUST:*}
+spring.mail.password=${SPRING_MAIL_PASSWORD:}
+spring.mail.username=${SPRING_MAIL_USERNAME:}
 
 gov.pay.operational_services=ccd_gw
 

--- a/api/src/main/resources/db/changelog/db.changelog-0.1.13.yaml
+++ b/api/src/main/resources/db/changelog/db.changelog-0.1.13.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1710000000000-1
+      author: DaveJ
+      changes:
+        - sql:
+          splitStatements:
+          sql: >
+            CREATE SEQUENCE IF NOT EXISTS payment_reference_seq START 1750000000000;

--- a/api/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/api/src/main/resources/db/changelog/db.changelog-master.xml
@@ -25,4 +25,5 @@
     <include file="db/changelog/db.changelog-0.1.10.yaml"/>
     <include file="db/changelog/db.changelog-0.1.11.yaml"/>
     <include file="db/changelog/db.changelog-0.1.12.yaml"/>
+    <include file="db/changelog/db.changelog-0.1.13.yaml"/>
 </databaseChangeLog>

--- a/api/src/test/java/uk/gov/hmcts/payment/api/mapper/ServiceRequestDtoDomainMapperTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/mapper/ServiceRequestDtoDomainMapperTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.payment.api.contract.util.CurrencyCode;
+import uk.gov.hmcts.payment.api.controllers.PaymentReference;
 import uk.gov.hmcts.payment.api.domain.mapper.ServiceRequestDtoDomainMapper;
 import uk.gov.hmcts.payment.api.domain.model.ServiceRequestBo;
 import uk.gov.hmcts.payment.api.domain.model.ServiceRequestOnlinePaymentBo;
@@ -42,6 +43,9 @@ public class ServiceRequestDtoDomainMapperTest {
     @Mock
     ServiceIdSupplier serviceIdSupplier;
 
+    @Mock
+    PaymentReference paymentReference;
+
     @Test
     public void toDomainTest(){
 
@@ -57,11 +61,14 @@ public class ServiceRequestDtoDomainMapperTest {
             .serviceDescription("DIVORCE")
             .build();
 
+        Mockito.when(paymentReference.getNext()).thenReturn("2024-1234567890");
+
         ServiceRequestBo serviceRequestBo = serviceRequestDtoDomainMapper.toDomain(serviceRequestDto,organisationalServiceDto);
 
         assertTrue(serviceRequestBo.getOrgId().equals("AA001"));
         assertTrue(serviceRequestBo.getEnterpriseServiceName().equals("DIVORCE"));
         assertTrue(serviceRequestBo.getCcdCaseNumber().equals("8689869686968696"));
+        assertTrue(serviceRequestBo.getReference().equals("2024-1234567890"));
 
     }
 

--- a/charts/payment-api/Chart.yaml
+++ b/charts/payment-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Helm chart for the HMCTS payment api
 name: payment-api
 home: https://github.com/hmcts/ccpay-payment-app
-version: 2.3.33
+version: 2.3.34
 maintainers:
   - name: HMCTS Fees & Payments Dev Team
     email: ccpay@hmcts.net

--- a/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentFeeLinkRepository.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentFeeLinkRepository.java
@@ -26,4 +26,6 @@ public interface PaymentFeeLinkRepository extends CrudRepository<PaymentFeeLink,
     Optional<PaymentFeeLink> findByPaymentReferenceAndFeeId(final @Param("paymentReference") String paymentReference,
                                          final @Param("feeId") Integer feeId);
 
+    @Query(value = "SELECT concat(date_part('year', now()),'-',nextval('payment_reference_seq'))", nativeQuery = true)
+    String getNextPaymentReference();
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-7137

### Change description ###
Turn service request payment reference into a sequence. 

This is required so when multiple service requests come in at the same time, the old date based creation of the service request number based on milliseconds from epoch was generating the same service-request number. With the based on a sequence, this will never happen.

The format of the number hasn't changed. It's still based on the the same format as before with the first number being the current year and the second number now being based off the sequence payment_reference_seq.
YYYY-nnnnnnnnnnnnn
I.e. 2024-1750000000163

This should not have any impact on external or internals services and should gaurentee that each Service Request has a unique payment reference.

The sequence starts from 2024-1750000000000 in all environments.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
