### PR TITLE
PAY-7310: Update to fix IAC Issue

### DIFF
--- a/api/src/main/java/uk/gov/hmcts/payment/api/service/IacService.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/service/IacService.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface IacService {
     ResponseEntity<SupplementaryPaymentDto> getIacSupplementaryInfo(List<PaymentDto> paymentDtos, String serviceName);
+
+    void updateCaseReferenceInPaymentDtos(List<PaymentDto> paymentDtos, String serviceName);
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/service/IacServiceImpl.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/service/IacServiceImpl.java
@@ -13,8 +13,11 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.payment.api.contract.FeeDto;
 import uk.gov.hmcts.payment.api.contract.PaymentDto;
 import uk.gov.hmcts.payment.api.dto.*;
+import uk.gov.hmcts.payment.api.model.PaymentFeeLink;
+import uk.gov.hmcts.payment.api.model.PaymentFeeLinkRepository;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 
 import java.util.ArrayList;
@@ -33,14 +36,17 @@ public class IacServiceImpl implements IacService {
     private RestTemplate restTemplateIacSupplementaryInfo;
 
     @Autowired
+    private PaymentFeeLinkRepository paymentFeeLinkRepository;
+
+    @Autowired
     private AuthTokenGenerator authTokenGenerator;
 
     @Override
     public ResponseEntity<SupplementaryPaymentDto> getIacSupplementaryInfo(List<PaymentDto> paymentDtos, String serviceName) {
        HttpStatus paymentResponseHttpStatus = HttpStatus.OK;
         boolean isExceptionOccur = false;
-        List<PaymentDto> iacPayments = paymentDtos.stream().filter(payment -> (payment.getServiceName().equalsIgnoreCase(serviceName))).
-            collect(Collectors.toList());
+
+        List<PaymentDto> iacPayments = getIacPayments(serviceName, paymentDtos);
         LOG.info("No of Iac payment retrieved  : {}", iacPayments.size());
 
         List<String> iacCcdCaseNos = iacPayments.stream().map(paymentDto -> paymentDto.getCcdCaseNumber()).
@@ -85,6 +91,24 @@ public class IacServiceImpl implements IacService {
                     build();
             }
            return new ResponseEntity(supplementaryPaymentDto, paymentResponseHttpStatus);
+    }
+
+    @Override
+    public void updateCaseReferenceInPaymentDtos(List<PaymentDto> paymentDtos, String serviceName) {
+        List<PaymentDto> iacPayments = getIacPayments(serviceName, paymentDtos);
+        iacPayments.forEach(paymentDto ->
+            paymentFeeLinkRepository.findByCcdCaseNumber(paymentDto.getCcdCaseNumber()).ifPresent(paymentFeeLinks ->
+                paymentFeeLinks.stream().filter(paymentLink -> paymentDto.getCaseReference() == null && paymentLink.getCaseReference() != null).findFirst().ifPresent(paymentLink -> {
+                    paymentDto.setCaseReference(paymentLink.getCaseReference());
+                    LOG.info("Setting caseReference {} from paymentFeeLink for CCD Case {}", paymentLink.getCaseReference(), paymentDto.getCcdCaseNumber());
+                })
+            )
+        );
+    }
+
+    private List<PaymentDto> getIacPayments(String serviceName, List<PaymentDto> paymentDtos) {
+        return paymentDtos.stream().filter(payment -> (payment.getServiceName().equalsIgnoreCase(serviceName))).
+            collect(Collectors.toList());
     }
 
     private ResponseEntity<SupplementaryDetailsResponse> getIacSupplementaryInfoResponse(List<String> iacCcdCaseNos) throws RestClientException {

--- a/api/src/test/java/uk/gov/hmcts/payment/api/service/IacServiceTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/service/IacServiceTest.java
@@ -1,0 +1,131 @@
+package uk.gov.hmcts.payment.api.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.payment.api.contract.PaymentDto;
+import uk.gov.hmcts.payment.api.dto.SupplementaryDetailsResponse;
+import uk.gov.hmcts.payment.api.dto.SupplementaryPaymentDto;
+import uk.gov.hmcts.payment.api.model.PaymentFeeLink;
+import uk.gov.hmcts.payment.api.model.PaymentFeeLinkRepository;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class IacServiceTest {
+
+    @Mock
+    private PaymentFeeLinkRepository paymentFeeLinkRepository;
+
+    @Mock
+    private RestTemplate restTemplateIacSupplementaryInfo;
+
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+
+    @InjectMocks
+    private IacServiceImpl iacService;
+
+    static private String IAC_SERVICE_NAME = "IAC";
+
+    PaymentDto paymentDto;
+
+    @Before
+    public void setUp() {
+        paymentDto =  PaymentDto.payment2DtoWith()
+            .paymentReference("RC-2222-3333-4444-5555")
+            .ccdCaseNumber("1111-2222-3333-4444")
+            .caseReference(null)
+            .serviceName(IAC_SERVICE_NAME)
+            .amount(BigDecimal.valueOf(1)).build();
+
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void getIacSupplementaryInfoSuccess() {
+        List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
+        ResponseEntity<SupplementaryDetailsResponse> responseEntity = new ResponseEntity<>(new SupplementaryDetailsResponse(), HttpStatus.OK);
+        when(restTemplateIacSupplementaryInfo.exchange(anyString(), any(), any(), eq(SupplementaryDetailsResponse.class)))
+            .thenReturn(responseEntity);
+
+        ResponseEntity<SupplementaryPaymentDto> result = iacService.getIacSupplementaryInfo(paymentDtos, IAC_SERVICE_NAME);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertNotNull(result.getBody());
+    }
+
+    @Test
+    public void getIacSupplementaryInfoHttpClientErrorException() {
+        List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
+        when(restTemplateIacSupplementaryInfo.exchange(anyString(), any(), any(), eq(SupplementaryDetailsResponse.class)))
+            .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+        ResponseEntity<SupplementaryPaymentDto> result = iacService.getIacSupplementaryInfo(paymentDtos, IAC_SERVICE_NAME);
+
+        assertEquals(HttpStatus.PARTIAL_CONTENT, result.getStatusCode());
+    }
+
+    @Test
+    public void updateCaseReferenceInPaymentDtosSuccess() {
+        List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
+        PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").caseReference("IAC/1234/REF").build();
+        when(paymentFeeLinkRepository.findByCcdCaseNumber("1111-2222-3333-4444")).thenReturn(Optional.of(Collections.singletonList(paymentFeeLink)));
+
+        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_NAME);
+
+        assertEquals("IAC/1234/REF", paymentDto.getCaseReference());
+    }
+
+    @Test
+    public void updateCaseReferenceInPaymentDtosMultipleFeeLinksSuccess() {
+        List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
+        PaymentFeeLink paymentFeeLink1 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").build();
+        PaymentFeeLink paymentFeeLink2 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").build();
+        PaymentFeeLink paymentFeeLink3 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").caseReference("IAC/1234/REF").build();
+        PaymentFeeLink paymentFeeLink4 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").build();
+
+        List<PaymentFeeLink> paymentFeeLinks = List.of(paymentFeeLink1, paymentFeeLink2, paymentFeeLink3, paymentFeeLink4);
+        when(paymentFeeLinkRepository.findByCcdCaseNumber("1111-2222-3333-4444")).thenReturn(Optional.of(paymentFeeLinks));
+
+        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_NAME);
+
+        assertEquals("IAC/1234/REF", paymentDto.getCaseReference());
+    }
+
+    @Test
+    public void updateCaseReferenceInPaymentDtosIgnoredAsAlreadyPopulated() {
+        paymentDto.setCaseReference("IAC/1234/REF");
+        List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
+        PaymentFeeLink paymentFeeLink = new PaymentFeeLink();
+        paymentFeeLink.setCaseReference("IAC/6789/REF");
+        when(paymentFeeLinkRepository.findByCcdCaseNumber(anyString())).thenReturn(Optional.of(Collections.singletonList(paymentFeeLink)));
+
+        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_NAME);
+
+        assertEquals("IAC/1234/REF", paymentDto.getCaseReference());
+    }
+
+    @Test
+    public void updateCaseReferenceInPaymentDtosNoCaseReference() {
+        List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
+        when(paymentFeeLinkRepository.findByCcdCaseNumber(anyString())).thenReturn(Optional.empty());
+
+        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_NAME);
+
+        assertNull(paymentDto.getCaseReference());
+    }
+}

--- a/api/src/test/java/uk/gov/hmcts/payment/api/service/IacServiceTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/service/IacServiceTest.java
@@ -39,7 +39,7 @@ public class IacServiceTest {
     @InjectMocks
     private IacServiceImpl iacService;
 
-    static private String IAC_SERVICE_NAME = "IAC";
+    static private String IAC_SERVICE_CODE = "IAC";
 
     PaymentDto paymentDto;
 
@@ -49,7 +49,7 @@ public class IacServiceTest {
             .paymentReference("RC-2222-3333-4444-5555")
             .ccdCaseNumber("1111-2222-3333-4444")
             .caseReference(null)
-            .serviceName(IAC_SERVICE_NAME)
+            .serviceName(IAC_SERVICE_CODE)
             .amount(BigDecimal.valueOf(1)).build();
 
         MockitoAnnotations.openMocks(this);
@@ -62,7 +62,7 @@ public class IacServiceTest {
         when(restTemplateIacSupplementaryInfo.exchange(anyString(), any(), any(), eq(SupplementaryDetailsResponse.class)))
             .thenReturn(responseEntity);
 
-        ResponseEntity<SupplementaryPaymentDto> result = iacService.getIacSupplementaryInfo(paymentDtos, IAC_SERVICE_NAME);
+        ResponseEntity<SupplementaryPaymentDto> result = iacService.getIacSupplementaryInfo(paymentDtos, IAC_SERVICE_CODE);
 
         assertEquals(HttpStatus.OK, result.getStatusCode());
         assertNotNull(result.getBody());
@@ -74,7 +74,7 @@ public class IacServiceTest {
         when(restTemplateIacSupplementaryInfo.exchange(anyString(), any(), any(), eq(SupplementaryDetailsResponse.class)))
             .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 
-        ResponseEntity<SupplementaryPaymentDto> result = iacService.getIacSupplementaryInfo(paymentDtos, IAC_SERVICE_NAME);
+        ResponseEntity<SupplementaryPaymentDto> result = iacService.getIacSupplementaryInfo(paymentDtos, IAC_SERVICE_CODE);
 
         assertEquals(HttpStatus.PARTIAL_CONTENT, result.getStatusCode());
     }
@@ -85,7 +85,7 @@ public class IacServiceTest {
         PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").caseReference("IAC/1234/REF").build();
         when(paymentFeeLinkRepository.findByCcdCaseNumber("1111-2222-3333-4444")).thenReturn(Optional.of(Collections.singletonList(paymentFeeLink)));
 
-        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_NAME);
+        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_CODE);
 
         assertEquals("IAC/1234/REF", paymentDto.getCaseReference());
     }
@@ -97,11 +97,10 @@ public class IacServiceTest {
         PaymentFeeLink paymentFeeLink2 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").build();
         PaymentFeeLink paymentFeeLink3 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").caseReference("IAC/1234/REF").build();
         PaymentFeeLink paymentFeeLink4 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").build();
-
         List<PaymentFeeLink> paymentFeeLinks = List.of(paymentFeeLink1, paymentFeeLink2, paymentFeeLink3, paymentFeeLink4);
         when(paymentFeeLinkRepository.findByCcdCaseNumber("1111-2222-3333-4444")).thenReturn(Optional.of(paymentFeeLinks));
 
-        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_NAME);
+        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_CODE);
 
         assertEquals("IAC/1234/REF", paymentDto.getCaseReference());
     }
@@ -110,11 +109,10 @@ public class IacServiceTest {
     public void updateCaseReferenceInPaymentDtosIgnoredAsAlreadyPopulated() {
         paymentDto.setCaseReference("IAC/1234/REF");
         List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
-        PaymentFeeLink paymentFeeLink = new PaymentFeeLink();
-        paymentFeeLink.setCaseReference("IAC/6789/REF");
+        PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().caseReference("IAC/6789/REF").build();
         when(paymentFeeLinkRepository.findByCcdCaseNumber(anyString())).thenReturn(Optional.of(Collections.singletonList(paymentFeeLink)));
 
-        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_NAME);
+        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_CODE);
 
         assertEquals("IAC/1234/REF", paymentDto.getCaseReference());
     }
@@ -124,7 +122,7 @@ public class IacServiceTest {
         List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
         when(paymentFeeLinkRepository.findByCcdCaseNumber(anyString())).thenReturn(Optional.empty());
 
-        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_NAME);
+        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_CODE);
 
         assertNull(paymentDto.getCaseReference());
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id "org.sonarqube" version "5.0.0.4638"
+    id "org.sonarqube" version "5.1.0.4882"
     id 'org.springframework.boot' version '2.7.18'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'org.owasp.dependencycheck' version '9.1.0'


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-7310


### Change description
This code update hooks of the back of the IAC Supplimentary data collection for IAC Reconciliation Reports and adds a search to identify the Case Reference from the PaymentFeeLink record should one not be provided in the payment record.

The seach looks for a PaymentFeeLink against the case, there might be multiple PaymentFeeLink records, so the first one found with a Case Reference string is used for the Reconciliation Report. It's impossible for a case to have more than one Case Reference, so this should be a safe change.


### Testing done
Extensive tests performed in the IacServiceTest class. Multiple PaymentFeeLink records have been tested against a case. Also tested cases with an existing Case Reference which shouldn't change. The IacService is only invoked for IAC cases during the Reconciliation Report.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
