### PR TITLE
PAY-7310: Update to identify Case Reference by Payment Group

### DIFF
--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
@@ -344,7 +344,7 @@ public class PaymentDtoMapper {
         LOG.info("apportionCheck value in PaymentDtoMapper: {}",apportionCheck);
         PaymentDto paymentDto = PaymentDto.payment2DtoWith()
             .paymentReference(payment.getReference())
-            .paymentGroupReference(apportionCheck ? null : paymentReference)
+            .paymentGroupReference(paymentReference)
             .serviceName(payment.getServiceType())
             .siteId(payment.getSiteId())
             .amount(payment.getAmount())

--- a/api/src/test/java/uk/gov/hmcts/payment/api/service/IacServiceTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/service/IacServiceTest.java
@@ -46,6 +46,7 @@ public class IacServiceTest {
     @Before
     public void setUp() {
         paymentDto =  PaymentDto.payment2DtoWith()
+            .paymentGroupReference("2024-1706099566733")
             .paymentReference("RC-2222-3333-4444-5555")
             .ccdCaseNumber("1111-2222-3333-4444")
             .caseReference(null)
@@ -80,25 +81,10 @@ public class IacServiceTest {
     }
 
     @Test
-    public void updateCaseReferenceInPaymentDtosSuccess() {
+    public void updateCaseReferenceInPaymentDtoFeeLinksSuccess() {
         List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
-        PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").caseReference("IAC/1234/REF").build();
-        when(paymentFeeLinkRepository.findByCcdCaseNumber("1111-2222-3333-4444")).thenReturn(Optional.of(Collections.singletonList(paymentFeeLink)));
-
-        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_CODE);
-
-        assertEquals("IAC/1234/REF", paymentDto.getCaseReference());
-    }
-
-    @Test
-    public void updateCaseReferenceInPaymentDtosMultipleFeeLinksSuccess() {
-        List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
-        PaymentFeeLink paymentFeeLink1 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").build();
-        PaymentFeeLink paymentFeeLink2 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").build();
-        PaymentFeeLink paymentFeeLink3 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").caseReference("IAC/1234/REF").build();
-        PaymentFeeLink paymentFeeLink4 = PaymentFeeLink.paymentFeeLinkWith().ccdCaseNumber("1111-2222-3333-4444").build();
-        List<PaymentFeeLink> paymentFeeLinks = List.of(paymentFeeLink1, paymentFeeLink2, paymentFeeLink3, paymentFeeLink4);
-        when(paymentFeeLinkRepository.findByCcdCaseNumber("1111-2222-3333-4444")).thenReturn(Optional.of(paymentFeeLinks));
+        PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().paymentReference("2024-1706099566733").caseReference("IAC/1234/REF").build();
+        when(paymentFeeLinkRepository.findByPaymentReference("2024-1706099566733")).thenReturn(Optional.of(paymentFeeLink));
 
         iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_CODE);
 
@@ -110,11 +96,23 @@ public class IacServiceTest {
         paymentDto.setCaseReference("IAC/1234/REF");
         List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
         PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().caseReference("IAC/6789/REF").build();
-        when(paymentFeeLinkRepository.findByCcdCaseNumber(anyString())).thenReturn(Optional.of(Collections.singletonList(paymentFeeLink)));
+        when(paymentFeeLinkRepository.findByPaymentReference(anyString())).thenReturn(Optional.of(paymentFeeLink));
 
         iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_CODE);
 
         assertEquals("IAC/1234/REF", paymentDto.getCaseReference());
+    }
+
+
+    @Test
+    public void updateCaseReferenceInPaymentDtosEmptyCaseReference() {
+        List<PaymentDto> paymentDtos = Collections.singletonList(paymentDto);
+        PaymentFeeLink paymentFeeLink = PaymentFeeLink.paymentFeeLinkWith().paymentReference("2024-1706099566733").caseReference("").build();
+        when(paymentFeeLinkRepository.findByPaymentReference("2024-1706099566733")).thenReturn(Optional.of(paymentFeeLink));
+
+        iacService.updateCaseReferenceInPaymentDtos(paymentDtos, IAC_SERVICE_CODE);
+
+        assertEquals(null, paymentDto.getCaseReference());
     }
 
     @Test


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PAY-7310

### Change description

This code update hooks of the back of the IAC Supplimentary data collection for IAC Reconciliation Reports and adds a search to identify the Case Reference from the PaymentFeeLink record should one not be provided in the payment record.

The search looks for a PaymentFeeLink against the case using the Payment Group (Service Request) which should be unique across a case. If a Case Reference was found in the PaymentFeeLink and it was missing in the Payment record, then it gets used in the IAC Reconciliation Report.

Please note for this to work, it has to be an IAC case and the payment has to be made from a Payment Group (Service Request) which has a populated Case Reference. Currently only Service Requests created from CCD have a Case Reference available.

### Testing done

Unit tests configured to pickup care reference from payment group during IAC reconciliation. Manual testing also in Demo.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
