### PR TITLE
Pay 7213 pact contract verification

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -245,7 +245,6 @@ task providerContractTest(type: Test) {
 
 task runProviderPactVerification(type: Test) {
     logger.lifecycle("Runs pact provider Tests")
-    systemProperty 'pact.verifier.publishResults','true'
     testClassesDirs = sourceSets.contractTest.output.classesDirs
     classpath = sourceSets.contractTest.runtimeClasspath
 }

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CreditAccountPaymentProviderTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CreditAccountPaymentProviderTest.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.payment.api.configuration.LaunchDarklyFeatureToggler;
 import uk.gov.hmcts.payment.api.controllers.CreditAccountPaymentController;
+import uk.gov.hmcts.payment.api.controllers.PaymentReference;
 import uk.gov.hmcts.payment.api.dto.AccountDto;
 import uk.gov.hmcts.payment.api.dto.OrganisationalServiceDto;
 import uk.gov.hmcts.payment.api.dto.mapper.CreditAccountDtoMapper;
@@ -69,6 +70,8 @@ class CreditAccountPaymentProviderTest {
     FeePayApportionRepository feePayApportionRepository;
     @Autowired
     PaymentFeeRepository paymentFeeRepository;
+    @Autowired
+    PaymentReference paymentReferenceMock;
     @Autowired
     FF4j ff4j;
     @Autowired
@@ -130,7 +133,7 @@ class CreditAccountPaymentProviderTest {
         testTarget.setControllers(
             new CreditAccountPaymentController(creditAccountPaymentService, creditAccountDtoMapper, accountServiceMock, paymentValidator,
                 feePayApportionService, featureToggler, pbaStatusErrorMapper, requestMapper, Arrays.asList("CMC"), paymentService,
-                referenceDataService, authTokenGenerator));
+                referenceDataService, authTokenGenerator, paymentReferenceMock));
         if (context != null) {
             context.setTarget(testTarget);
         }

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CreditAccountPaymentProviderTestConfiguration.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CreditAccountPaymentProviderTestConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Primary;
 import uk.gov.hmcts.payment.api.audit.AuditRepository;
 import uk.gov.hmcts.payment.api.configuration.LaunchDarklyFeatureToggler;
 import uk.gov.hmcts.payment.api.configuration.security.AuthenticatedServiceIdSupplier;
+import uk.gov.hmcts.payment.api.controllers.PaymentReference;
 import uk.gov.hmcts.payment.api.dto.AccountDto;
 import uk.gov.hmcts.payment.api.dto.mapper.CreditAccountDtoMapper;
 import uk.gov.hmcts.payment.api.dto.mapper.PaymentDtoMapper;
@@ -76,6 +77,13 @@ public class CreditAccountPaymentProviderTestConfiguration {
     PaymentMethodRepository paymentMethodRepository;
     @MockBean
     Payment2Repository payment2Repository;
+
+    @Bean
+    @Primary
+    PaymentReference paymentReference(){
+
+        return new PaymentReference(paymentFeeLinkRepository());
+    }
     @MockBean
     ServiceIdSupplier serviceIdSupplier;
     @MockBean

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CreditAccountPaymentController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CreditAccountPaymentController.java
@@ -78,7 +78,8 @@ public class CreditAccountPaymentController {
         PBAStatusErrorMapper pbaStatusErrorMapper,
         CreditAccountPaymentRequestMapper requestMapper, @Value("#{'${pba.config1.service.names}'.split(',')}") List<String> pbaConfig1ServiceNames,
         PaymentService<PaymentFeeLink, String> paymentService, ReferenceDataService referenceDataService,
-        AuthTokenGenerator authTokenGenerator) {
+        AuthTokenGenerator authTokenGenerator,
+        PaymentReference paymentReference) {
         this.creditAccountPaymentService = creditAccountPaymentService;
         this.creditAccountDtoMapper = creditAccountDtoMapper;
         this.accountService = accountService;
@@ -91,6 +92,7 @@ public class CreditAccountPaymentController {
         this.paymentService = paymentService;
         this.referenceDataService = referenceDataService;
         this.authTokenGenerator = authTokenGenerator;
+        this.paymentReference = paymentReference;
     }
 
     @Operation(summary = "Create credit account payment", description = "Create credit account payment")

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentReference.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/PaymentReference.java
@@ -7,11 +7,15 @@ import uk.gov.hmcts.payment.api.model.PaymentFeeLinkRepository;
 @Component
 public class PaymentReference {
 
-    @Autowired
     private PaymentFeeLinkRepository paymentFeeLinkRepository;
 
     public String getNext() {
         return paymentFeeLinkRepository.getNextPaymentReference();
+    }
+
+    @Autowired
+    public PaymentReference(PaymentFeeLinkRepository paymentFeeLinkRepository) {
+        this.paymentFeeLinkRepository = paymentFeeLinkRepository;
     }
 
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-7213

### Change description
Some subtle changes around the use of PaymentReference over the last 8 months broke the contract tests because it was turning up as a null in the mock environment. These changes make it available as a bean. Also removing the setting of publishResults to true, because this very likely having the opposite effect. Other projects that succesfully publish their results do not use this, and our results havn't been published for 8 months, which is how we have missed the error with PaymentReference.


### Testing done
Contract tests now working. Not all of them, but it's an improvement.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
