### PR TITLE
PAY-7443: Service Request Online Card Duplicate Payment Update

### DIFF
--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/ServiceRequestProviderTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/ServiceRequestProviderTest.java
@@ -17,6 +17,8 @@ import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.payment.api.controllers.ServiceRequestController;
 import uk.gov.hmcts.payment.api.domain.service.ServiceRequestDomainService;
@@ -80,7 +82,8 @@ class ServiceRequestProviderTest {
             .status("Initiated")
             .dateCreated(creationDate)
             .build();
-        when(serviceRequestDomainServiceMock.create(any(OnlineCardPaymentRequest.class), eq("2022-1662375472431"), eq("https://localhost"), ArgumentMatchers.isNull(), )).thenReturn(onlineCardPaymentResponse);
+        ResponseEntity<OnlineCardPaymentResponse> onlineCardPaymentResponseEntity = new ResponseEntity(onlineCardPaymentResponse, HttpStatus.CREATED);
+        when(serviceRequestDomainServiceMock.create(any(OnlineCardPaymentRequest.class), eq("2022-1662375472431"), eq("https://localhost"), ArgumentMatchers.isNull())).thenReturn(onlineCardPaymentResponseEntity);
 
     }
 }

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/ServiceRequestProviderTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/ServiceRequestProviderTest.java
@@ -80,7 +80,7 @@ class ServiceRequestProviderTest {
             .status("Initiated")
             .dateCreated(creationDate)
             .build();
-        when(serviceRequestDomainServiceMock.create(any(OnlineCardPaymentRequest.class), eq("2022-1662375472431"), eq("https://localhost"), ArgumentMatchers.isNull())).thenReturn(onlineCardPaymentResponse);
+        when(serviceRequestDomainServiceMock.create(any(OnlineCardPaymentRequest.class), eq("2022-1662375472431"), eq("https://localhost"), ArgumentMatchers.isNull(), )).thenReturn(onlineCardPaymentResponse);
 
     }
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestController.java
@@ -286,6 +286,7 @@ public class ServiceRequestController {
     @Operation(summary = "Create online card payment", description = "Create online card payment")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "Payment created"),
+        @ApiResponse(responseCode = "302", description = "A successful payment request has been made in GovPay, redirecting back to the return URL"),
         @ApiResponse(responseCode = "400", description = "Bad request. Payment creation failed"),
         @ApiResponse(responseCode = "403", description = "Unauthenticated request"),
         @ApiResponse(responseCode = "404", description = "Service request not found"),

--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainService.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainService.java
@@ -46,5 +46,4 @@ public interface ServiceRequestDomainService {
 
     IMessageReceiver createDLQConnection() throws ServiceBusException, InterruptedException;
 
-    PaymentDto updateStatusByInternalReferenceAndSendStatusNotification(String internalReference) throws JsonProcessingException;
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainService.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainService.java
@@ -7,6 +7,7 @@ import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.apache.commons.validator.routines.checkdigit.CheckDigitException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
+import uk.gov.hmcts.payment.api.contract.PaymentDto;
 import uk.gov.hmcts.payment.api.domain.model.ServiceRequestPaymentBo;
 import uk.gov.hmcts.payment.api.dto.*;
 import uk.gov.hmcts.payment.api.dto.servicerequest.ServiceRequestDto;
@@ -14,6 +15,7 @@ import uk.gov.hmcts.payment.api.dto.servicerequest.ServiceRequestPaymentDto;
 import uk.gov.hmcts.payment.api.model.IdempotencyKeys;
 import uk.gov.hmcts.payment.api.model.PaymentFeeLink;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 
@@ -27,7 +29,7 @@ public interface ServiceRequestDomainService {
 
     ServiceRequestPaymentBo addPayments(PaymentFeeLink serviceRequest, String serviceRequestReference, ServiceRequestPaymentDto serviceRequestPaymentDto) throws CheckDigitException;
 
-    OnlineCardPaymentResponse create(OnlineCardPaymentRequest onlineCardPaymentRequest, String serviceRequestReference, String returnURL, String serviceCallbackURL) throws CheckDigitException;
+    ResponseEntity<OnlineCardPaymentResponse> create(OnlineCardPaymentRequest onlineCardPaymentRequest, String serviceRequestReference, String returnURL, String serviceCallbackURL) throws CheckDigitException;
 
     PaymentFeeLink businessValidationForServiceRequests(PaymentFeeLink serviceRequest, ServiceRequestPaymentDto serviceRequestPaymentDto);
 
@@ -43,4 +45,6 @@ public interface ServiceRequestDomainService {
     void deadLetterProcess(IMessageReceiver subscriptionClient) throws ServiceBusException, InterruptedException, IOException;
 
     IMessageReceiver createDLQConnection() throws ServiceBusException, InterruptedException;
+
+    PaymentDto updateStatusByInternalReferenceAndSendStatusNotification(String internalReference) throws JsonProcessingException;
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainServiceImpl.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainServiceImpl.java
@@ -397,8 +397,8 @@ public class ServiceRequestDomainServiceImpl implements ServiceRequestDomainServ
 
         if (successPayment.isPresent()) {
             LOG.info("Payment {} for serviceRequest {} already exists with status success in PayHub.",
-                successPayment.get().getReference(),
-                successPayment.get().getPaymentLink().getPaymentReference());
+                    successPayment.map(Payment::getReference).orElse("N/A"),
+                    successPayment.map(apayment -> apayment.getPaymentLink().getPaymentReference()).orElse("N/A"));
             return true;
         }
 
@@ -413,8 +413,8 @@ public class ServiceRequestDomainServiceImpl implements ServiceRequestDomainServ
             GovPayPayment payment = delegateGovPay.retrieve(existingPayment.get().getExternalReference());
             if (payment.getState().getStatus().equals("success")) {
                 LOG.info("Payment {} for serviceRequest {} already exists with status success in GovPay.",
-                    existingPayment.get().getReference(),
-                    existingPayment.get().getPaymentLink().getPaymentReference());
+                        existingPayment.map(Payment::getReference).orElse("N/A"),
+                        existingPayment.map(apayment -> apayment.getPaymentLink().getPaymentReference()).orElse("N/A"));
                 return true;
             }
         }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -74,7 +74,7 @@ gov.pay.auth.key.iac=${GOV_PAY_AUTH_KEY_IAC:}
 gov.pay.auth.key.adoption_web=${GOV_PAY_AUTH_KEY_ADOPTION:}
 gov.pay.auth.key.prl_cos_api=${GOV_PAY_AUTH_KEY_PRL:}
 gov.pay.auth.key.nfdiv_case_api=${GOV_PAY_AUTH_KEY_NFDIV_CASE_API:}
-gov.pay.url=${GOV_PAY_URL:#{https://publicapi.payments.service.gov.uk/v1/payments}}
+gov.pay.url=${GOV_PAY_URL:#{"https://publicapi.payments.service.gov.uk/v1/payments"}}
 gov.pay.operational_services=${GOV_PAY_OPERATIONAL_SERVICES:#{ccd_gw,api_gw}}
 
 

--- a/api/src/test/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestControllerTest.java
@@ -1069,7 +1069,12 @@ public class ServiceRequestControllerTest {
             .paymentReference("RC-ref")
             .build();
 
-        when(serviceRequestDomainService.create(any(),any(),any(),any(), )).thenReturn(onlineCardPaymentResponse);
+        ResponseEntity<OnlineCardPaymentResponse> response = new ResponseEntity<>(onlineCardPaymentResponse, HttpStatus.CREATED);
+        when(serviceRequestDomainService.create(any(),any(),any(),any())).thenReturn(response);
+
+        when(govPayClient.createPayment(anyString(), any())).thenReturn(getGovPayPayment());
+
+        when(serviceRequestDomainService.create(any(),any(),any(),any())).thenReturn(response);
 
         MvcResult result = restActions
             .post("/service-request/" + serviceRequestReference + "/card-payments", onlineCardPaymentRequest)
@@ -1160,7 +1165,8 @@ public class ServiceRequestControllerTest {
 
         OnlineCardPaymentResponse onlineCardPaymentResponseSample = OnlineCardPaymentResponse.onlineCardPaymentResponseWith().status("created").build();
 
-        when(serviceRequestDomainService.create(any(),any(),any(),any(), )).thenReturn(onlineCardPaymentResponseSample);
+        ResponseEntity<OnlineCardPaymentResponse> response = new ResponseEntity<>(onlineCardPaymentResponseSample, HttpStatus.CREATED);
+        when(serviceRequestDomainService.create(any(),any(),any(),any())).thenReturn(response);
 
 
         MvcResult result = restActions
@@ -1189,8 +1195,9 @@ public class ServiceRequestControllerTest {
         when(govPayClient.createPayment(anyString(), any())).thenReturn(getGovPayPayment());
 
         OnlineCardPaymentResponse onlineCardPaymentResponseSample = OnlineCardPaymentResponse.onlineCardPaymentResponseWith().status("created").build();
+        ResponseEntity<OnlineCardPaymentResponse> response = new ResponseEntity<>(onlineCardPaymentResponseSample, HttpStatus.CREATED);
 
-        when(serviceRequestDomainService.create(any(),any(),any(),any(), )).thenReturn(onlineCardPaymentResponseSample);
+        when(serviceRequestDomainService.create(any(),any(),any(),any())).thenReturn(response);
 
         MvcResult result = restActions
             .withHeader("service-callback-url", "dummy")

--- a/api/src/test/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/controllers/ServiceRequestControllerTest.java
@@ -32,7 +32,6 @@ import uk.gov.hmcts.payment.api.domain.service.IdempotencyService;
 import uk.gov.hmcts.payment.api.domain.service.ServiceRequestDomainService;
 import uk.gov.hmcts.payment.api.dto.*;
 import uk.gov.hmcts.payment.api.dto.PaymentReference;
-import uk.gov.hmcts.payment.api.dto.mapper.PaymentDtoMapper;
 import uk.gov.hmcts.payment.api.dto.mapper.PaymentGroupDtoMapper;
 import uk.gov.hmcts.payment.api.dto.servicerequest.ServiceRequestDto;
 import uk.gov.hmcts.payment.api.dto.servicerequest.ServiceRequestFeeDto;
@@ -1070,7 +1069,7 @@ public class ServiceRequestControllerTest {
             .paymentReference("RC-ref")
             .build();
 
-        when(serviceRequestDomainService.create(any(),any(),any(),any())).thenReturn(onlineCardPaymentResponse);
+        when(serviceRequestDomainService.create(any(),any(),any(),any(), )).thenReturn(onlineCardPaymentResponse);
 
         MvcResult result = restActions
             .post("/service-request/" + serviceRequestReference + "/card-payments", onlineCardPaymentRequest)
@@ -1161,7 +1160,7 @@ public class ServiceRequestControllerTest {
 
         OnlineCardPaymentResponse onlineCardPaymentResponseSample = OnlineCardPaymentResponse.onlineCardPaymentResponseWith().status("created").build();
 
-        when(serviceRequestDomainService.create(any(),any(),any(),any())).thenReturn(onlineCardPaymentResponseSample);
+        when(serviceRequestDomainService.create(any(),any(),any(),any(), )).thenReturn(onlineCardPaymentResponseSample);
 
 
         MvcResult result = restActions
@@ -1191,7 +1190,7 @@ public class ServiceRequestControllerTest {
 
         OnlineCardPaymentResponse onlineCardPaymentResponseSample = OnlineCardPaymentResponse.onlineCardPaymentResponseWith().status("created").build();
 
-        when(serviceRequestDomainService.create(any(),any(),any(),any())).thenReturn(onlineCardPaymentResponseSample);
+        when(serviceRequestDomainService.create(any(),any(),any(),any(), )).thenReturn(onlineCardPaymentResponseSample);
 
         MvcResult result = restActions
             .withHeader("service-callback-url", "dummy")

--- a/api/src/test/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainServiceTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainServiceTest.java
@@ -50,7 +50,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -612,7 +611,7 @@ public class ServiceRequestDomainServiceTest {
 
         when(featureToggler.getBooleanValue(any(),any())).thenReturn(true);
 
-        OnlineCardPaymentResponse onlineCardPaymentResponse = serviceRequestDomainService.create(onlineCardPaymentRequest,"","","");
+        OnlineCardPaymentResponse onlineCardPaymentResponse = serviceRequestDomainService.create(onlineCardPaymentRequest,"","","", );
 
         assertNotNull(onlineCardPaymentResponse);
     }
@@ -657,7 +656,7 @@ public class ServiceRequestDomainServiceTest {
 
         when(paymentFeeLinkMock.getPayments()).thenReturn(getPaymentFeeLinkWithPayments().getPayments());
 
-        OnlineCardPaymentResponse onlineCardPaymentResponse = serviceRequestDomainService.create(onlineCardPaymentRequest,"","","");
+        OnlineCardPaymentResponse onlineCardPaymentResponse = serviceRequestDomainService.create(onlineCardPaymentRequest,"","","", );
 
         assertNotNull(onlineCardPaymentResponse);
 

--- a/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentStatus.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentStatus.java
@@ -17,7 +17,6 @@ import javax.persistence.*;
 public class PaymentStatus {
 
     public final static PaymentStatus CREATED = new PaymentStatus("created", "created");
-    public final static PaymentStatus STARTED = new PaymentStatus("started", "started");
     public final static PaymentStatus SUCCESS = new PaymentStatus("success", "success");
     public final static PaymentStatus CANCELLED = new PaymentStatus("cancelled", "cancelled");
     public final static PaymentStatus PENDING = new PaymentStatus("pending", "pending");

--- a/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentStatus.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/model/PaymentStatus.java
@@ -17,7 +17,11 @@ import javax.persistence.*;
 public class PaymentStatus {
 
     public final static PaymentStatus CREATED = new PaymentStatus("created", "created");
+    public final static PaymentStatus STARTED = new PaymentStatus("started", "started");
     public final static PaymentStatus SUCCESS = new PaymentStatus("success", "success");
+    public final static PaymentStatus CANCELLED = new PaymentStatus("cancelled", "cancelled");
+    public final static PaymentStatus PENDING = new PaymentStatus("pending", "pending");
+    public final static PaymentStatus ERROR = new PaymentStatus("error", "error");
     public final static PaymentStatus FAILED = new PaymentStatus("failed", "failed");
 
     @Id


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-7443

### Change description
The Civil CUI Release 2 had an issue with session's expiring which caused duplicate payments to be pushed through multiple times. 

To prevent this from happing from a Fee and Payment perspective, this endpoint is being updated to provide an additional check for a valid payment. If a valid payment is found, the user is returned to the application they came from via the return URL, instead of being sent through to the GovPay card payment process.

_/card-payments/{internal-reference}/card-payments_

### Testing done

After the business validation has been completed, a new check has been included _hasOnlineCardPaymentAlreadySuccess_ which performs if true returns the user to the supplied 'return-url'. The checks are as follows.

A. Find the first existing payment in the Payment DB with the following matching criteria:
1. Payment Reference (Service Request)
2. Payment Status is SUCCESS
3. Payment Provider is 'gov pay'.

B. Find the first existing payment in GovPay with the following matching criteria:
1. Payment Reference (Service Request)
2. Payment Status is SUCCESS
3. Payment Provider is 'gov pay'.
4. Payment is less than 90 minutes.

Both of these scenarios are covered in detail in the Unit tests. The conditions for A is checked first and if this doesn't match, B is also checked, either one being true results in the user being sent back to the website, instead of going through the GovPay journey. GovPay has a 90 minute check because all payments after that period are automatically expired if not successfully paid.

I've also checked Production and found there are no Service Requests with more than a single 'created' payment, so this supports the validation of the update.

This will be further tested in the Demo environment through happy path, and with the Civil team on the various scenarios which caused duplicate payments.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
