### PR TITLE
PAY-7474 fix contract test for probate_caveatsFrontEnd

### DIFF
--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CardPaymentProviderTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CardPaymentProviderTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.fees2.register.data.service.FeeService;
 import uk.gov.hmcts.payment.api.configuration.LaunchDarklyFeatureToggler;
 import uk.gov.hmcts.payment.api.controllers.CardPaymentController;
 import uk.gov.hmcts.payment.api.controllers.PaymentController;
+import uk.gov.hmcts.payment.api.controllers.PaymentReference;
 import uk.gov.hmcts.payment.api.dto.mapper.PaymentDtoMapper;
 import uk.gov.hmcts.payment.api.external.client.GovPayClient;
 import uk.gov.hmcts.payment.api.external.client.dto.CardDetails;
@@ -135,6 +136,9 @@ class CardPaymentProviderTest {
     @Autowired
     GovPayKeyRepository govPayKeyRepositoryMock;
 
+    @Autowired
+    PaymentReference paymentReferenceMock;
+
     @Value("${PACT_BRANCH_NAME}")
     String branchName;
 
@@ -151,9 +155,10 @@ class CardPaymentProviderTest {
     void before(PactVerificationContext context) {
         System.getProperties().setProperty("pact.verifier.publishResults", "true");
         MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        when(paymentReferenceMock.getNext()).thenReturn("123");
         CardPaymentController cardPaymentController =
             new CardPaymentController(cardDelegatingPaymentService, paymentDtoMapper, cardDetailsService, pciPalPaymentService, ff4j,
-                feePayApportionService, featureToggler, referenceDataService);
+                feePayApportionService, featureToggler, referenceDataService, paymentReferenceMock);
         cardPaymentController.setApplicationContext(applicationContext);
         testTarget.setControllers(
             cardPaymentController,

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CardPaymentProviderTestConfiguration.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/provider/CardPaymentProviderTestConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.payment.api.audit.AuditRepository;
 import uk.gov.hmcts.payment.api.configuration.LaunchDarklyFeatureToggler;
 import uk.gov.hmcts.payment.api.configuration.security.AuthenticatedServiceIdSupplier;
+import uk.gov.hmcts.payment.api.controllers.PaymentReference;
 import uk.gov.hmcts.payment.api.dto.PciPalPayment;
 import uk.gov.hmcts.payment.api.dto.mapper.PaymentDtoMapper;
 import uk.gov.hmcts.payment.api.external.client.GovPayClient;
@@ -191,5 +192,8 @@ public class CardPaymentProviderTestConfiguration {
 
     @MockBean
     ServiceRequestCaseUtil serviceRequestCaseUtil;
+
+    @MockBean
+    PaymentReference paymentReference;
 
 }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CardPaymentController.java
@@ -86,7 +86,6 @@ public class CardPaymentController implements ApplicationContextAware {
 
     private ApplicationContext applicationContext;
 
-    @Autowired
     private PaymentReference paymentReference;
 
     @Autowired
@@ -95,7 +94,10 @@ public class CardPaymentController implements ApplicationContextAware {
                                  CardDetailsService<CardDetails, String> cardDetailsService,
                                  PciPalPaymentService pciPalPaymentService,
                                  FF4j ff4j,
-                                 FeePayApportionService feePayApportionService, LaunchDarklyFeatureToggler featureToggler, ReferenceDataService referenceDataService) {
+                                 FeePayApportionService feePayApportionService,
+                                 LaunchDarklyFeatureToggler featureToggler,
+                                 ReferenceDataService referenceDataService,
+                                 PaymentReference paymentReference){
         this.delegatingPaymentService = cardDelegatingPaymentService;
         this.paymentDtoMapper = paymentDtoMapper;
         this.cardDetailsService = cardDetailsService;
@@ -103,6 +105,7 @@ public class CardPaymentController implements ApplicationContextAware {
         this.feePayApportionService = feePayApportionService;
         this.featureToggler = featureToggler;
         this.referenceDataService = referenceDataService;
+        this.paymentReference = paymentReference;
     }
 
     @Operation(summary = "Create card payment", description = "Create card payment")


### PR DESCRIPTION
### Jira link


See [PAY-7474](https://tools.hmcts.net/jira/browse/PAY-7474)

### Change description

This contract test was failing with a null pointer exception since the introduction of PaymentReference.
This fix sets up the mock and passes it into the constructor.

### Testing done

Works locally and also on pact broker.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
