### PR TITLE
PAY-7552: Update to improve uniqueness of RC number generation

### DIFF
--- a/model/src/main/java/uk/gov/hmcts/payment/api/util/ReferenceUtil.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/util/ReferenceUtil.java
@@ -14,16 +14,16 @@ public class ReferenceUtil {
 
     private static final String PAYMENT_REF_REGEX = "(?<=\\G.{4})";
 
-    public String getNext(String prefix) throws CheckDigitException {
+    public String getNext2(String prefix) throws CheckDigitException {
         DateTime dateTime = new DateTime(DateTimeZone.UTC);
-        long timeInMillis = dateTime.getMillis() / 100;
+        long timeInMillis = dateTime.getMillis() / 10;
 
         StringBuilder sb = new StringBuilder();
         sb.append(timeInMillis);
 
         // append the random 4 characters
         SecureRandom random = new SecureRandom();
-        sb.append(String.format("%04d", random.nextInt(10000)));
+        sb.append(String.format("%03d", random.nextInt(1000)));
 
         CheckDigit checkDigit = new LuhnCheckDigit();
         sb.append(checkDigit.calculate(sb.toString()));

--- a/model/src/main/java/uk/gov/hmcts/payment/api/util/ReferenceUtil.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/util/ReferenceUtil.java
@@ -7,23 +7,23 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.springframework.stereotype.Component;
 
-import java.security.SecureRandom;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Component
 public class ReferenceUtil {
 
     private static final String PAYMENT_REF_REGEX = "(?<=\\G.{4})";
 
-    public String getNext2(String prefix) throws CheckDigitException {
+    public String getNext(String prefix) throws CheckDigitException {
         DateTime dateTime = new DateTime(DateTimeZone.UTC);
         long timeInMillis = dateTime.getMillis() / 10;
 
         StringBuilder sb = new StringBuilder();
         sb.append(timeInMillis);
 
-        // append the random 4 characters
-        SecureRandom random = new SecureRandom();
-        sb.append(String.format("%03d", random.nextInt(1000)));
+        // append the random 3 digits
+        int randomDigits = ThreadLocalRandom.current().nextInt(1000);
+        sb.append(String.format("%03d", randomDigits));
 
         CheckDigit checkDigit = new LuhnCheckDigit();
         sb.append(checkDigit.calculate(sb.toString()));

--- a/model/src/main/java/uk/gov/hmcts/payment/api/util/ReferenceUtil.java
+++ b/model/src/main/java/uk/gov/hmcts/payment/api/util/ReferenceUtil.java
@@ -7,7 +7,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.security.SecureRandom;
 
 @Component
 public class ReferenceUtil {
@@ -22,8 +22,9 @@ public class ReferenceUtil {
         sb.append(timeInMillis);
 
         // append the random 3 digits
-        int randomDigits = ThreadLocalRandom.current().nextInt(1000);
-        sb.append(String.format("%03d", randomDigits));
+        SecureRandom random = new SecureRandom();
+        sb.append(String.format("%03d", random.nextInt(1000)));
+
 
         CheckDigit checkDigit = new LuhnCheckDigit();
         sb.append(checkDigit.calculate(sb.toString()));

--- a/model/src/test/java/uk/gov/hmcts/payment/api/util/ReferenceUtilTest.java
+++ b/model/src/test/java/uk/gov/hmcts/payment/api/util/ReferenceUtilTest.java
@@ -1,16 +1,46 @@
 package uk.gov.hmcts.payment.api.util;
 
 import org.apache.commons.validator.routines.checkdigit.CheckDigitException;
-import org.junit.Test;
+import org.apache.commons.validator.routines.checkdigit.LuhnCheckDigit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReferenceUtilTest {
 
+    private ReferenceUtil referenceUtil;
+    private LuhnCheckDigit luhnCheckDigit;
+
+    @BeforeEach
+    public void setUp() {
+        referenceUtil = new ReferenceUtil();
+        luhnCheckDigit = new LuhnCheckDigit();
+    }
+
     @Test
-    public void testGetNext() throws CheckDigitException {
-        ReferenceUtil referenceUtil = new ReferenceUtil();
+    public void getNextTest() throws CheckDigitException {
         String result = referenceUtil.getNext("test");
-        assertEquals(24,result.length());
+        assertEquals(24, result.length());
+    }
+
+    @Test
+    public void luhnDigitValidateTest() throws CheckDigitException {
+        String result = referenceUtil.getNext("test");
+        String refNumberWithCheckDigit = result.substring(5).replace("-", "");
+
+        assertTrue(luhnCheckDigit.isValid(refNumberWithCheckDigit));
+    }
+
+    @Test
+    public void getNextWithPrefixRCTest() throws CheckDigitException {
+        String result = referenceUtil.getNext("RC");
+        String regex = "^RC-\\d{4}-\\d{4}-\\d{4}-\\d{4}$";
+        Pattern pattern = Pattern.compile(regex);
+
+        assertTrue(pattern.matcher(result).matches(), "The reference does not match the expected format");
     }
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-7552

### Change description
Minor change to the RC generation.

Current format RC-XXXX-XXXX-XXXR-RRRL
Where
X - DateTime millisecond number / 100
R - 4 Digit SecureRandom Generated Number
L - Luhn forumla check digit

New apporach is to remove the devision in the milliseconds as that's losing precision - this means the random rumber drops from 4 digits to 2.

Current format RC-XXXX-XXXX-XXXX-XRRL
Where
X - DateTime millisecond number
R - 2 Digit SecureRandom Generated Number
L - Luhn forumla check digit

In tests from 1000 consecutive requests - not particularly realistic, ~7000 average collisions for the old code, ~6000 average collisions for the new code, but the new code should work better is real world scenarios.
### Testing done

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
