### PR TITLE
PAY-7556: Update Payment Status Job for Robustness When Collecting Payment

### DIFF
--- a/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/jobs/MaintenanceJobsControllerMockTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/componenttests/jobs/MaintenanceJobsControllerMockTest.java
@@ -18,9 +18,7 @@ import uk.gov.hmcts.payment.api.service.PaymentService;
 import java.util.Arrays;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -77,6 +75,19 @@ public class MaintenanceJobsControllerMockTest {
 
         verify(delegatingPaymentService, times(2)).retrieveWithCallBack("xxx");
 
+    }
+
+    @Test
+    public void testExceptionWhileUpdatingPaymentStatus() throws Exception {
+        Reference reference = new Reference("invalid-reference");
+        doReturn(Arrays.asList(reference)).when(paymentService).listInitiatedStatusPaymentsReferences();
+        doThrow(new RuntimeException("Test Exception")).when(delegatingPaymentService).retrieveWithCallBack(reference.getReference());
+
+        this.mockMvc.perform(patch("/jobs/card-payments-status-update"))
+            .andExpect(status().isOk());
+
+        verify(paymentService).listInitiatedStatusPaymentsReferences();
+        verify(delegatingPaymentService).retrieveWithCallBack(reference.getReference());
     }
 
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-7556

### Change description
Wrap delegatingPaymentService.retrieveWithCallBack(reference.getReference()) request in try catch as a rogue payment status was causing an error when retrieving the payment from GovPay.

### Testing done
Tests have been updated, and the outcome in the environments will be observed. Current process in Prod is broken due to the rogue payment being inaccessible with a 401 error and causing the job process to crash.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
