### PR TITLE
PAY-7625: Updated to default volume in CSV generation

### DIFF
--- a/api-contract/src/main/java/uk/gov/hmcts/payment/api/contract/PaymentDto.java
+++ b/api-contract/src/main/java/uk/gov/hmcts/payment/api/contract/PaymentDto.java
@@ -187,7 +187,7 @@ public class PaymentDto {
                 .add(getStatus())
                 .add(getChannel())
                 .add(getMethod())
-                .add(getAmount().toString())
+                .add(getAmount() != null ? getAmount().toString() : "0.00")
                 .add(getSiteId());
 
             String memolineWithQuotes = fee.getMemoLine() != null ? new StringBuffer().append('"').append(fee.getMemoLine()).append('"').toString() : "";
@@ -195,10 +195,10 @@ public class PaymentDto {
 
             sb.add(fee.getCode())
                 .add(fee.getVersion())
-                .add(fee.getCalculatedAmount().toString())
+                .add(fee.getCalculatedAmount() != null ? fee.getCalculatedAmount().toString() : "0.00")
                 .add(memolineWithQuotes)
                 .add(naturalAccountCode)
-                .add(fee.getVolume().toString());
+                .add(fee.getVolume() != null ? fee.getVolume().toString() : "1");
             result.add(sb.toString());
         }
 

--- a/api-contract/src/test/java/uk/gov/hmcts/payment/api/contract/PaymentDtoTest.java
+++ b/api-contract/src/test/java/uk/gov/hmcts/payment/api/contract/PaymentDtoTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.payment.api.contract;
 
 
+import com.sun.tools.xjc.model.CDefaultValue;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -13,7 +14,6 @@ import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Ignore
 public class PaymentDtoTest {
 
     private final String feeWithVolumeCode;
@@ -68,8 +68,11 @@ public class PaymentDtoTest {
     private Boolean remissionEnable;
     private String internalReference;
     private List<DisputeDto> disputeDto;
+    private String defaultVolum;
 
     public PaymentDtoTest() {
+        amount = new BigDecimal(1);
+        defaultVolum = "1";
         feeWithVolumeCode = "X0001";
         feeVersion = "3";
         calculatedAmountForFeeWithVolume = new BigDecimal(1);
@@ -93,47 +96,62 @@ public class PaymentDtoTest {
         paymentGroupReference = "paymentGroupReference";
         apportionedPayment = new BigDecimal(1);
         dateReceiptProcessed = currentDateTime.toDate();
-
+        sdf = new SimpleDateFormat("dd MMM yyyy HH:mm:ss zzz");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        List<StatusHistoryDto> statusHistories = new ArrayList<>();
+        List<PaymentAllocationDto> paymentAllocations = new ArrayList<>();
     }
 
     @Before
     public void beforeEach() {
-        sdf = new SimpleDateFormat("dd MMM yyyy HH:mm:ss zzz");
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        DateTime currentDateTime = new DateTime();
-        dateCreated = currentDateTime.toDate();
-        dateUpdated = currentDateTime.plusDays(1).toDate();
-        List<StatusHistoryDto> statusHistories = new ArrayList<>();
-        List<PaymentAllocationDto> paymentAllocations = new ArrayList<>();
-        PaymentDto.LinksDto links = new PaymentDto.LinksDto();
+        testDto = defaultTestDto(testDto);
+        feeNoVolumeDto = FeeDto.feeDtoWith().feeAmount(feeAmount).code(feeNoVolumeCode).version(feeVersion)
+            .calculatedAmount(calculatedAmountForFeeNoVolume).memoLine(memoLine).naturalAccountCode(naturalAccountCode)
+            .description(feeDescription).caseReference(caseReference).apportionAmount(apportionAmount)
+            .allocatedAmount(allocatedAmount).dateApportioned(dateApportioned).dateCreated(dateCreated)
+            .dateUpdated(dateUpdated).amountDue(amountDue).paymentGroupReference(paymentGroupReference)
+            .apportionedPayment(apportionedPayment).dateReceiptProcessed(dateReceiptProcessed).build();
 
-        amount = new BigDecimal(1);
-        id = "1";
-        description = "description";
-        reference = "reference";
-        gbp = CurrencyCode.GBP;
-        ccdNumber = "ccdNumber";
-        caseReference = "caseReference";
-        paymentReference = "paymentReference";
-        channel = "channel";
-        method = "method";
-        externalProvider = "externalProvider";
-        status = "status";
-        externalReference = "externalReference";
-        siteId = "siteId";
-        serviceName = "serviceName";
-        customerReference = "customerReference";
-        accountNumber = "accountNumber";
-        organisationName = "organisationName";
-        paymentGroupReference = "paymentGroupReference";
-        giroSlipNo = "giroSlipNo";
-        reportedDateOffline = new Date();
-        documentControlNumber = "12345";
-        bankedDate = new Date();
-        payerName = "test";
-        refundEnable = true;
-        remissionEnable=true;
+        feeWithVolumeDto = FeeDto.feeDtoWith().feeAmount(feeAmount).code(feeWithVolumeCode).version(feeVersion)
+            .calculatedAmount(calculatedAmountForFeeNoVolume).memoLine(memoLine).naturalAccountCode(naturalAccountCode)
+            .description(feeDescription).caseReference(caseReference).apportionAmount(apportionAmount)
+            .allocatedAmount(allocatedAmount).dateApportioned(dateApportioned).dateCreated(dateCreated)
+            .dateUpdated(dateUpdated).amountDue(amountDue).paymentGroupReference(paymentGroupReference)
+            .apportionedPayment(apportionedPayment).dateReceiptProcessed(dateReceiptProcessed).volume(volume).build();
     }
+
+    private PaymentDto defaultTestDto(PaymentDto paymentDto) {
+        paymentDto = new PaymentDto();
+        paymentDto.setAmount(amount);
+        paymentDto.setCaseReference(caseReference);
+        paymentDto.setCcdCaseNumber(ccdNumber);
+        paymentDto.setChannel(channel);
+        paymentDto.setCurrency(gbp);
+        paymentDto.setDateCreated(dateCreated);
+        paymentDto.setDateUpdated(dateUpdated);
+        paymentDto.setDescription(description);
+        paymentDto.setExternalProvider(externalProvider);
+        paymentDto.setExternalReference(externalReference);
+        paymentDto.setId(id);
+        paymentDto.setMethod(method);
+        paymentDto.setOrganisationName(organisationName);
+        paymentDto.setPaymentGroupReference(paymentGroupReference);
+        paymentDto.setPaymentReference(paymentReference);
+        paymentDto.setReference(reference);
+        paymentDto.setSiteId(siteId);
+        paymentDto.setStatus(status);
+        paymentDto.setServiceName(serviceName);
+        paymentDto.setCustomerReference(customerReference);
+        paymentDto.setAccountNumber(accountNumber);
+        paymentDto.setGiroSlipNo(giroSlipNo);
+        paymentDto.setReportedDateOffline(reportedDateOffline);
+        paymentDto.setDocumentControlNumber(documentControlNumber);
+        paymentDto.setBankedDate(bankedDate);
+        paymentDto.setPayerName(payerName);
+        paymentDto.setRefundEnable(refundEnable);
+        return paymentDto;
+    }
+
 
     @Test
     public void cardPaymentCsvFillsVolumeAmountWhenExists() {
@@ -432,7 +450,7 @@ public class PaymentDtoTest {
             .add(calculatedAmountForFeeNoVolume.toString())
             .add("\"" + memoLine + "\"")
             .add(naturalAccountCode)
-            .add(volume.toString());
+            .add(defaultVolum);
 
         assertThat(testDto.toPaymentCsv()).isEqualTo(joiner.toString());
     }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/mapper/ServiceRequestDtoDomainMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/mapper/ServiceRequestDtoDomainMapper.java
@@ -64,7 +64,7 @@ public class ServiceRequestDtoDomainMapper {
             .code(serviceRequestFeeDto.getCode())
             .ccdCaseNumber(ccdCaseNumber)
             .version(serviceRequestFeeDto.getVersion())
-            .volume(serviceRequestFeeDto.getVolume())
+            .volume(serviceRequestFeeDto.getVolume() != null ? serviceRequestFeeDto.getVolume() : 1)
             .netAmount(serviceRequestFeeDto.getCalculatedAmount())
             .build();
     }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/service/PaymentRefundsServiceImpl.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/service/PaymentRefundsServiceImpl.java
@@ -620,8 +620,8 @@ public class PaymentRefundsServiceImpl implements PaymentRefundsService {
                                 || refundDto.getRefundStatus().getName().equalsIgnoreCase("Sent for approval"))) {
                                 totalRefundAmount = totalRefundAmount.add(refundDto.getAmount());
                             }
+                        }
                     }
-                }
                 }
             }
         }

--- a/api/src/main/resources/db/changelog/db.changelog-0.1.15.yaml
+++ b/api/src/main/resources/db/changelog/db.changelog-0.1.15.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1810000000000-2
+      author: DaveJ
+      changes:
+        - sql:
+          splitStatements:
+          sql: >
+            -- Set default volume to 1 and update existing null values (repeated from 0.1.14)
+            ALTER TABLE fee ALTER COLUMN volume SET DEFAULT 1;
+            UPDATE fee SET volume = 1 WHERE volume IS NULL;

--- a/api/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/api/src/main/resources/db/changelog/db.changelog-master.xml
@@ -27,4 +27,5 @@
     <include file="db/changelog/db.changelog-0.1.12.yaml"/>
     <include file="db/changelog/db.changelog-0.1.13.yaml"/>
     <include file="db/changelog/db.changelog-0.1.14.yaml"/>
+    <include file="db/changelog/db.changelog-0.1.15.yaml"/>
 </databaseChangeLog>

--- a/api/src/test/java/uk/gov/hmcts/payment/api/domain/mapper/ServiceRequestDtoDomainMapperTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/domain/mapper/ServiceRequestDtoDomainMapperTest.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.payment.api.domain.mapper;
+
+import org.junit.Test;
+import uk.gov.hmcts.payment.api.domain.model.ServiceRequestFeeBo;
+import uk.gov.hmcts.payment.api.dto.servicerequest.ServiceRequestFeeDto;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServiceRequestDtoDomainMapperTest {
+
+    private final ServiceRequestDtoDomainMapper mapper = new ServiceRequestDtoDomainMapper();
+
+    @Test
+    public void testToFeeDomainWithNonNullVolume() {
+        ServiceRequestFeeDto feeDto = ServiceRequestFeeDto.feeDtoWith()
+            .calculatedAmount(new BigDecimal("100.00"))
+            .code("FEE001")
+            .version("1")
+            .volume(5)
+            .build();
+
+        ServiceRequestFeeBo feeBo = mapper.toFeeDomain(feeDto, "123456789");
+
+        assertThat(feeBo.getCalculatedAmount()).isEqualByComparingTo(new BigDecimal("100.00"));
+        assertThat(feeBo.getCode()).isEqualTo("FEE001");
+        assertThat(feeBo.getCcdCaseNumber()).isEqualTo("123456789");
+        assertThat(feeBo.getVersion()).isEqualTo("1");
+        assertThat(feeBo.getVolume()).isEqualTo(5);
+        assertThat(feeBo.getNetAmount()).isEqualByComparingTo(new BigDecimal("100.00"));
+    }
+
+    @Test
+    public void testToFeeDomainWithNullVolume() {
+        ServiceRequestFeeDto feeDto = ServiceRequestFeeDto.feeDtoWith()
+            .calculatedAmount(new BigDecimal("100.00"))
+            .code("FEE001")
+            .version("1")
+            .volume(null)
+            .build();
+
+        ServiceRequestFeeBo feeBo = mapper.toFeeDomain(feeDto, "123456789");
+
+        assertThat(feeBo.getCalculatedAmount()).isEqualByComparingTo(new BigDecimal("100.00"));
+        assertThat(feeBo.getCode()).isEqualTo("FEE001");
+        assertThat(feeBo.getCcdCaseNumber()).isEqualTo("123456789");
+        assertThat(feeBo.getVersion()).isEqualTo("1");
+        assertThat(feeBo.getVolume()).isEqualTo(1); // Default volume to 1
+        assertThat(feeBo.getNetAmount()).isEqualByComparingTo(new BigDecimal("100.00"));
+    }
+}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-7625

### Change description
Missing volume in CSV generation. The value is defaulted at a DB level, so doesn't cause an issue in the code.

26/02/2025 I've done a second commit as on further investigation Divorce were creating SRs with an explicit null value for the volume, therefore ignoring the volume default value of 1 in the fee table. I've updated the code to select 1 as the default from the FeeDto object and rerun the SQL to update null volume values to 1 on top of the original change to correct the CSV to make it more robust when picking up possible null values.

### Testing done
Unit test updated, manual reconciliation report run.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
