### PR TITLE
Reverting java-logging as library has gone AWOL

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -76,7 +76,7 @@ def versions = [
         serenityCucumber: '4.2.16',
 ]
 
-def javaLoggingVersion = '6.1.8'
+def javaLoggingVersion = '6.1.7'
 
 dependencies {
     implementation project(':payment-gov-pay-client')

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api group: 'org.springframework.security', name: 'spring-security-oauth2-client', version: '6.0.8'
     implementation group: 'com.querydsl', name: 'querydsl-jpa', version:'5.1.0'
     api group: 'commons-validator', name: 'commons-validator', version:'1.9.0'
-    implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.8'
+    implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.7'
     implementation (group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.0') {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-7686

### Change description
Payment App - DTSPO-24952: Looks like the HMCTS java-logging library 6.1.8 not available, reverted back to 6.1.7 which is still accessible. Can be corrected once  DTSPO-24952 has been resolved.

### Testing done
Blocking FT, once these pass and application logging can be confirmed, that should be enough. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
