### PR TITLE
CME-718 bump some libs

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -95,10 +95,10 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.17.0'
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.0'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.16'
-    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.16'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.18'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.18'
     implementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.17.0'
@@ -122,7 +122,7 @@ dependencies {
     implementation group: 'org.ff4j', name: 'ff4j-spring-boot-starter-webmvc', version: '2.1'
     implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-thymeleaf'
-    implementation(group: 'org.postgresql', name: 'postgresql', version: '42.7.5') {
+    implementation(group: 'org.postgresql', name: 'postgresql', version: '42.7.7') {
         exclude(module: 'commons-logging')
         exclude(module: 'slf4j-simple')
     }

--- a/api/liquibase.gradle
+++ b/api/liquibase.gradle
@@ -11,7 +11,7 @@ task liquibaseDiffChangelog(type: JavaExec) {
 
     classpath sourceSets.main.runtimeClasspath
     classpath configurations.liquibase
-    main = "liquibase.integration.commandline.Main"
+    mainClass = "liquibase.integration.commandline.Main"
 
     args "--changeLogFile=" + "$projectDir/src/main/resources/db/changelog/db.changelog-diff-" + buildTimestamp() + ".xml"
     args "--referenceUrl=hibernate:spring:uk.gov.hmcts.payment.api.model?dialect=org.hibernate.dialect.PostgreSQL94Dialect"
@@ -27,7 +27,7 @@ task migratePostgresDatabase(type: JavaExec) {
 
     classpath sourceSets.main.runtimeClasspath
     classpath configurations.liquibase
-    main = "liquibase.integration.commandline.Main"
+    mainClass = "liquibase.integration.commandline.Main"
     systemProperty "liquibase.useDbLock", true
 
     def urlString = project.hasProperty("dburl") ? "jdbc:postgresql://$dburl" : liquibaseProps.getProperty('url')

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 plugins {
     id 'application'
-    id "org.sonarqube" version "5.1.0.4882"
-    id 'org.springframework.boot' version '3.3.4'
+    id "org.sonarqube" version "6.2.0.5505"
+    id 'org.springframework.boot' version '3.3.12'
     id 'io.spring.dependency-management' version '1.1.7'
-    id 'org.owasp.dependencycheck' version '10.0.4'
-    id "uk.gov.hmcts.java" version '0.12.65'
-    id "com.gorylenko.gradle-git-properties" version "2.4.2"
+    id 'org.owasp.dependencycheck' version '12.1.3'
+    id "uk.gov.hmcts.java" version '0.12.66'
+    id "com.gorylenko.gradle-git-properties" version "2.5.0"
     id 'jacoco'
 }
 
-def springBootVersion = '3.3.4'
+def springBootVersion = '3.3.12'
 def springCloudVersion = '2023.0.5'
 
 def versions = [
@@ -71,11 +71,11 @@ allprojects {
                 entry 'jackson-databind'
             }
             // CVE-2020-8908
-            dependencySet(group: 'com.google.guava', version: '33.4.0-jre') {
+            dependencySet(group: 'com.google.guava', version: '33.4.8-jre') {
                 entry 'guava'
             }
 
-            dependencySet(group: 'ch.qos.logback', version: '1.5.16') {
+            dependencySet(group: 'ch.qos.logback', version: '1.5.18') {
                 entry 'logback-core'
                 entry 'logback-classic'
             }

--- a/cve-resolution-strategy.gradle
+++ b/cve-resolution-strategy.gradle
@@ -4,17 +4,6 @@ configurations.all {
             /* JAR upgrades with latest versions for CVE fixes*/
 
             /*
-                CVE-2021-28165, CVE-2021-28163, CVE-2021-28164, CVE-2021-28165, CVE-2021-28169, CVE-2021-34429
-            * */
-            if (det.requested.name == 'jetty-client' || det.requested.name == 'jetty-continuation' || det.requested.name == 'jetty-http'
-                    || det.requested.name == 'jetty-security' || det.requested.name == 'jetty-servlet' || det.requested.name == 'jetty-servlets'
-                    || det.requested.name == 'jetty-util' || det.requested.name == 'jetty-webapp' || det.requested.name == 'jetty-xml'
-                    || det.requested.name == 'jetty-server' || det.requested.name == 'jetty-_http_server' || det.requested.name == 'jetty-util-ajax'
-                    || det.requested.name == 'mortbay_jetty' || det.requested.name == 'jetty-io') {
-                det.useVersion '11.0.18'
-            }
-
-            /*
                 For compatibility with Powermockito
             */
             if (det.requested.group == 'org.mockito') {
@@ -23,12 +12,7 @@ configurations.all {
 
             /*CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090, CVE-2024-26308*/
             if (det.requested.name == 'commons-compress') {
-                det.useVersion '1.26.0'
-            }
-
-            /* CVE-2024-1597 */
-            if (det.requested.name == 'postgresql' && det.requested.group == 'org.postgresql') {
-                det.useVersion '42.7.3'
+                det.useVersion '1.26.2'
             }
 
             /* CVE-2025-24813 */
@@ -36,10 +20,9 @@ configurations.all {
                 det.useVersion '9.38'
             }
 
-            /* CVE-2025-24813 */
-            if (['tomcat-embed-core', 'tomcat-embed-websocket', 'tomcat-embed-jasper', 'tomcat-embed-el'].contains(det.requested.name)) {
-                println "Forcing ${det.requested.name} version from ${det.requested.version} to 10.1.40"
-                det.useVersion '10.1.40'
+            /* CVE-2025-48734 */
+            if (det.requested.group == 'commons-beanutils') {
+                det.useVersion '1.11.0'
             }
         }
     }

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-        <notes>
-            Description
-            Improper Access Control vulnerability in Apache Commons. A special BeanIntrospector class was added in version 1.9.2.
-            This can be used to stop attackers from using the declared class property of Java enum objects to get access to the classloader.
-        </notes>
-        <cve>CVE-2025-48734</cve>
-    </suppress>
 </suppressions>

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':payment-gov-pay-client')
     implementation project(':payment-reference-data')
     implementation project(':case-payment-orders-client')
-    implementation group: 'com.google.guava', name: 'guava', version: '33.4.0-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2'
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version:'7.4'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/CME-718

### Change description
Bump commons-lang3 to 3.17.0
Bump logback-classic and logback-core to 1.5.18
Bump postgresql to 42.7.7
Bump org.springframework.boot to 3.3.12
Bump org.sonarqube gradle plugin to 6.2.0.5505
Bump org.owasp.dependencycheck gradle plugin to 12.1.3
Bump com.gorylenko.gradle-git-properties gradle plugin to 2.5.0
Bump com.google.guava to 33.4.8-jre

Address some gradle deprecation warnings
