### PR TITLE
PAY-7956: Allow refunds to be added if initial PG has no payments

### DIFF
--- a/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CaseController.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/controllers/CaseController.java
@@ -143,6 +143,7 @@ public class CaseController {
                 }
             );
         }
+
     }
 
     private boolean isThereAnyPaymentReferenceInCurrentServiceRequest(List<PaymentDto> payments, String paymentReference){

--- a/api/src/test/java/uk/gov/hmcts/payment/api/controllers/CaseControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/controllers/CaseControllerTest.java
@@ -134,10 +134,6 @@ public class CaseControllerTest extends PaymentsDataUtil {
     private RefundRemissionEnableService refundRemissionEnableService;
     @MockBean
     private PaymentRefundsService paymentRefundsService;
-//    @MockBean
-//    private PaymentGroupService paymentGroupService;
-//    @MockBean
-//    private PaymentGroupDtoMapper paymentGroupDtoMapper;
     @MockBean
     @Autowired()
     @Qualifier("restTemplateRefundsGroup")


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-7956

### Change description
Minor change, when calling the following endpoint
@RequestMapping(value = "/cases/{ccdcasenumber}/paymentgroups", method = GET)

If adding a refund and a paymentgroup is found before a refund is added which doesn't have any payments to stream, then the code breaks and returns a HTTP 500 error. The code fix is to check that payments is not null before deciding if a payment exists.


### Testing done
Unit and FT tests passing. This is a pretty rare edge case as the first PaymentGroup for a payment being refunded is almost always likely to have a payment attempt.


### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
