### PR TITLE
PAY-8047: PBA: Move Apportionment before ServiceBus + extra logging

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -160,6 +160,8 @@ dependencies {
 
     // JUnit 4 dependencies
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.19.0'
+    testImplementation group: 'io.github.hakky54', name: 'logcaptor', version: '2.12.0'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.18'
     testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.10.0'
 
     // smoke

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -162,7 +162,6 @@ dependencies {
     testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
     testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.10.0'
-    testImplementation group:'net.bytebuddy', name: 'byte-buddy-agent', version: '1.17.7'
 
     // smoke
     smokeTestImplementation sourceSets.test.runtimeClasspath

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -159,8 +159,7 @@ dependencies {
     testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.20.4'
 
     // JUnit 4 dependencies
-    testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
-    testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.19.0'
     testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.10.0'
 
     // smoke

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -162,7 +162,7 @@ dependencies {
     testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
     testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.10.0'
-    testImplementation group:'net.bytebuddy', name: 'jbyte-buddy-agent', version: '1.17.7'
+    testImplementation group:'net.bytebuddy', name: 'byte-buddy-agent', version: '1.17.7'
 
     // smoke
     smokeTestImplementation sourceSets.test.runtimeClasspath

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -162,6 +162,7 @@ dependencies {
     testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
     testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.10.0'
+    testImplementation group:'net.bytebuddy', name: 'jbyte-buddy-agent', version: '1.17.7'
 
     // smoke
     smokeTestImplementation sourceSets.test.runtimeClasspath

--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainServiceImpl.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainServiceImpl.java
@@ -261,37 +261,40 @@ public class ServiceRequestDomainServiceImpl implements ServiceRequestDomainServ
         Payment payment = serviceRequestPaymentDomainDataEntityMapper.toEntity(serviceRequestPaymentBo, serviceRequest);
         payment.setPaymentLink(serviceRequest);
 
-        //2. Account check for PBA-Payment
+        // Account check for PBA-Payment
         payment = accountCheckForPBAPayment(serviceRequest, serviceRequestPaymentDto, payment);
 
-        List <Payment> paymentList = new ArrayList<Payment>();
-        paymentList.add(payment);
+        // Update payments list
+        serviceRequest.setPayments(Collections.singletonList(payment));
+        String serviceRequestStatus = paymentGroup.toPaymentGroupDto(serviceRequest).getServiceRequestStatus();
 
-        PaymentFeeLink serviceRequestWithUpdatedPaymentStatus = serviceRequest;
-        serviceRequestWithUpdatedPaymentStatus.setPayments(paymentList);
-        String serviceRequestStatus = paymentGroup.toPaymentGroupDto(serviceRequestWithUpdatedPaymentStatus).getServiceRequestStatus();
-
-        PaymentStatusDto paymentStatusDto = paymentDtoMapper.toPaymentStatusDto(serviceRequestReference,
-            serviceRequestPaymentBo.getAccountNumber(), payment, serviceRequestStatus);
+        PaymentStatusDto paymentStatusDto = paymentDtoMapper.toPaymentStatusDto(
+            serviceRequestReference,
+            serviceRequestPaymentBo.getAccountNumber(),
+            payment,
+            serviceRequestStatus
+        );
 
         PaymentFeeLink serviceRequestCallbackURL = paymentFeeLinkRepository.findByPaymentReference(serviceRequestReference)
             .orElseThrow(() -> new ServiceRequestReferenceNotFoundException("Order reference doesn't exist"));
-        sendMessageToTopic(paymentStatusDto, serviceRequestCallbackURL.getCallBackUrl());
-        LOG.info("Send PBA payment status to topic completed ");
 
-        if (payment.getPaymentStatus().getName().equals(PaymentStatus.FAILED.getName())) {
-            LOG.info("CreditAccountPayment Response 402(FORBIDDEN) for ccdCaseNumber : {} PaymentStatus : {}", payment.getCcdCaseNumber(), payment.getPaymentStatus().getName());
-            serviceRequestPaymentBo = serviceRequestPaymentDomainDataEntityMapper.toDomain(payment);
-            return serviceRequestPaymentBo;
+        if (PaymentStatus.FAILED.getName().equals(payment.getPaymentStatus().getName())) {
+            sendMessageToTopic(paymentStatusDto, serviceRequestCallbackURL.getCallBackUrl());
+            LOG.info("Send PBA payment status to topic completed");
+            LOG.info("CreditAccountPayment Response 402(FORBIDDEN) for ccdCaseNumber : {} PaymentStatus : {}",
+                payment.getCcdCaseNumber(), payment.getPaymentStatus().getName());
+            return serviceRequestPaymentDomainDataEntityMapper.toDomain(payment);
         }
 
-        // 3. Auto-Apportionment of Payment against serviceRequest Fees
+        // Auto-Apportionment of Payment against serviceRequest Fees
         extractApportionmentForPBA(serviceRequest);
 
+        // Send message to Topic for PBA Payment status
+        sendMessageToTopic(paymentStatusDto, serviceRequestCallbackURL.getCallBackUrl());
+        LOG.info("Send PBA payment status to topic completed");
         LOG.info("PBA add payment completed");
 
-        serviceRequestPaymentBo = serviceRequestPaymentDomainDataEntityMapper.toDomain(payment);
-        return serviceRequestPaymentBo;
+        return serviceRequestPaymentDomainDataEntityMapper.toDomain(payment);
     }
 
     private void extractApportionmentForPBA(PaymentFeeLink serviceRequest) {
@@ -577,7 +580,6 @@ public class ServiceRequestDomainServiceImpl implements ServiceRequestDomainServ
             LOG.info("Callback URL: {}", callBackUrl);
 
             if(payment!=null){
-
                 msg = new Message(objectMapper.writeValueAsString(payment));
                 topicClientCPO = new TopicClientProxy(connectionString, topicCardPBA);
 
@@ -598,6 +600,7 @@ public class ServiceRequestDomainServiceImpl implements ServiceRequestDomainServ
                 topicClientCPO.close();
             }
         } catch (Exception e) {
+            LOG.error("Error sending message to topic: {}", e.getMessage(), e);
             Thread.currentThread().interrupt();
         }
     }

--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainServiceImpl.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/ServiceRequestDomainServiceImpl.java
@@ -76,7 +76,6 @@ import uk.gov.hmcts.payment.api.v1.model.exceptions.ServiceRequestExceptionForNo
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -92,6 +91,7 @@ public class ServiceRequestDomainServiceImpl implements ServiceRequestDomainServ
     private static final Logger LOG = LoggerFactory.getLogger(ServiceRequestDomainServiceImpl.class);
     private static final String PAYMENT_PROVIDER_GOV_PAY= "gov pay";
     private static final String MSGCONTENTTYPE = "application/json";
+
     @Value("${case-payment-orders.api.url}")
     private  String callBackUrl;
 

--- a/api/src/main/java/uk/gov/hmcts/payment/api/servicebus/TopicClientProxy.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/servicebus/TopicClientProxy.java
@@ -51,7 +51,7 @@ public class TopicClientProxy {
         }
     }
 
-    private TopicClient newTopicClient() throws ServiceBusException, InterruptedException {
+    TopicClient newTopicClient() throws ServiceBusException, InterruptedException {
         ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(connectionString, topic);
         return new TopicClient(connectionStringBuilder);
     }

--- a/api/src/test/java/uk/gov/hmcts/payment/api/mapper/PBAStatusErrorMapperTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/mapper/PBAStatusErrorMapperTest.java
@@ -1,37 +1,22 @@
 package uk.gov.hmcts.payment.api.mapper;
 
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.Appender;
-import ch.qos.logback.core.read.ListAppender;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.runner.RunWith;
-import org.mockito.*;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.LoggingEvent;
 import uk.gov.hmcts.payment.api.contract.CreditAccountPaymentRequest;
 import uk.gov.hmcts.payment.api.dto.AccountDto;
 import uk.gov.hmcts.payment.api.model.Payment;
-import uk.gov.hmcts.payment.api.model.PaymentStatus;
 import uk.gov.hmcts.payment.api.util.AccountStatus;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static uk.gov.hmcts.payment.api.util.AccountStatus.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({LoggerFactory.class})
+@RunWith(MockitoJUnitRunner.class)
 public class PBAStatusErrorMapperTest {
     private static CreditAccountPaymentRequest creditAccountPaymentRequest;
 

--- a/api/src/test/java/uk/gov/hmcts/payment/api/service/IacServiceTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/service/IacServiceTest.java
@@ -2,11 +2,15 @@ package uk.gov.hmcts.payment.api.service;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.payment.api.contract.PaymentDto;
@@ -24,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@RunWith(SpringRunner.class)
+@DirtiesContext(classMode= DirtiesContext.ClassMode.AFTER_CLASS)
 public class IacServiceTest {
 
     @Mock

--- a/api/src/test/java/uk/gov/hmcts/payment/api/service/RefundRemissionEnableServiceTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/service/RefundRemissionEnableServiceTest.java
@@ -62,7 +62,7 @@ public class RefundRemissionEnableServiceTest {
     @Mock
     private FeePayApportionRepository feePayApportionRepository;
     @Mock
-    private PaymentService paymentService;
+    private PaymentService<PaymentFeeLink, String> paymentService;
     @Mock
     private RemissionRepository remissionRepository;
 

--- a/api/src/test/java/uk/gov/hmcts/payment/api/servicebus/TopicClientProxyTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/servicebus/TopicClientProxyTest.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.payment.api.servicebus;
+
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.TopicClient;
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import org.junit.Test;
+import org.mockito.Spy;
+
+import static org.mockito.Mockito.*;
+
+public class TopicClientProxyTest {
+
+    @Spy
+    private TopicClient client = mock(TopicClient.class);
+
+    @Spy
+    private IMessage message = mock(IMessage.class);
+
+    @Spy
+    TopicClientProxy proxy = new TopicClientProxy("conn", "topic");
+
+    @Test
+    public void shouldSendMessageSuccessfullyOnFirstAttempt() throws Exception {
+        var method = TopicClientProxy.class.getDeclaredMethod("send", TopicClient.class, IMessage.class);
+        method.setAccessible(true);
+
+        method.invoke(proxy, client, message);
+
+        verify(client, times(1)).send(message);
+    }
+
+    @Test
+    public void shouldRetryAndSucceedOnSecondAttempt() throws Exception {
+        doThrow(new ServiceBusException(false, "fail"))
+            .doNothing()
+            .when(client).send(message);
+
+        var method = TopicClientProxy.class.getDeclaredMethod("send", TopicClient.class, IMessage.class);
+        method.setAccessible(true);
+
+        method.invoke(proxy, client, message);
+
+        verify(client, times(2)).send(message);
+    }
+
+    @Test
+    public void shouldThrowAfterMaxRetries() throws Exception {
+        doThrow(new ServiceBusException(false, "fail"))
+            .when(client).send(message);
+
+        var method = TopicClientProxy.class.getDeclaredMethod("send", TopicClient.class, IMessage.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(proxy, client, message);
+        } catch (Exception e) {
+            // Expected: InvocationTargetException wrapping ServiceBusException
+            assert e.getCause() instanceof ServiceBusException;
+        }
+
+        verify(client, times(3)).send(message);
+    }
+}

--- a/api/src/test/java/uk/gov/hmcts/payment/api/servicebus/TopicClientProxyTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/servicebus/TopicClientProxyTest.java
@@ -4,6 +4,7 @@ import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.TopicClient;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 
 import static org.mockito.Mockito.*;
@@ -16,11 +17,11 @@ public class TopicClientProxyTest {
     @Spy
     private IMessage message = mock(IMessage.class);
 
-    @Spy
-    TopicClientProxy proxy = new TopicClientProxy("conn", "topic");
-
     @Test
     public void shouldSendMessageSuccessfullyOnFirstAttempt() throws Exception {
+        TopicClientProxy proxy = Mockito.spy(new TopicClientProxy("conn", "topic"));
+
+        // Use reflection to call private method
         var method = TopicClientProxy.class.getDeclaredMethod("send", TopicClient.class, IMessage.class);
         method.setAccessible(true);
 
@@ -31,6 +32,8 @@ public class TopicClientProxyTest {
 
     @Test
     public void shouldRetryAndSucceedOnSecondAttempt() throws Exception {
+        TopicClientProxy proxy = Mockito.spy(new TopicClientProxy("conn", "topic"));
+
         doThrow(new ServiceBusException(false, "fail"))
             .doNothing()
             .when(client).send(message);
@@ -45,6 +48,8 @@ public class TopicClientProxyTest {
 
     @Test
     public void shouldThrowAfterMaxRetries() throws Exception {
+        TopicClientProxy proxy = Mockito.spy(new TopicClientProxy("conn", "topic"));
+
         doThrow(new ServiceBusException(false, "fail"))
             .when(client).send(message);
 

--- a/api/src/test/java/uk/gov/hmcts/payment/api/servicebus/TopicClientProxyTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/servicebus/TopicClientProxyTest.java
@@ -1,13 +1,27 @@
 package uk.gov.hmcts.payment.api.servicebus;
 
 import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.MessageBody;
 import com.microsoft.azure.servicebus.TopicClient;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 
-import static org.mockito.Mockito.*;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TopicClientProxyTest {
 
@@ -18,10 +32,19 @@ public class TopicClientProxyTest {
     private IMessage message = mock(IMessage.class);
 
     @Test
+    public void shouldSendAMessageTest() throws Exception {
+        when(client.sendAsync(any(IMessage.class)))
+            .thenReturn(CompletableFuture.completedFuture(null));
+
+        client.sendAsync(message).join();
+
+        verify(client, times(1)).sendAsync(message);
+    }
+
+    @Test
     public void shouldSendMessageSuccessfullyOnFirstAttempt() throws Exception {
         TopicClientProxy proxy = Mockito.spy(new TopicClientProxy("conn", "topic"));
 
-        // Use reflection to call private method
         var method = TopicClientProxy.class.getDeclaredMethod("send", TopicClient.class, IMessage.class);
         method.setAccessible(true);
 
@@ -59,10 +82,49 @@ public class TopicClientProxyTest {
         try {
             method.invoke(proxy, client, message);
         } catch (Exception e) {
-            // Expected: InvocationTargetException wrapping ServiceBusException
             assert e.getCause() instanceof ServiceBusException;
         }
 
         verify(client, times(3)).send(message);
+    }
+
+    @Test
+    public void testSendWithKeepClientAliveFalse() throws Exception {
+        TopicClientProxy proxy = Mockito.spy(new TopicClientProxy("Endpoint=sb://servicebus-test.servicebus.windows.net/;SharedAccessKey=test", "topic"));
+
+        MessageBody body = MessageBody.fromValueData("Test message body".getBytes());
+        when(message.getMessageId()).thenReturn(UUID.randomUUID().toString());
+        when(message.getBody()).thenReturn(body.toString().getBytes());
+        when(message.getProperties()).thenReturn(Map.of("key", "value"));
+        when(message.getScheduledEnqueueTimeUtc()).thenReturn(Instant.now().plus(Duration.ofMinutes(5)));
+
+        when(client.sendAsync(any(IMessage.class))).thenReturn(CompletableFuture.completedFuture(null));
+        doReturn(client).when(proxy).newTopicClient();
+
+        proxy.setKeepClientAlive(false);
+        proxy.send(message);
+
+        verify(client, times(1)).send(any(IMessage.class));
+        verify(client).close();
+    }
+
+    @Test
+    public void testSendWithKeepClientAliveTrue() throws Exception {
+        TopicClientProxy proxy = Mockito.spy(new TopicClientProxy("Endpoint=sb://servicebus-test.servicebus.windows.net/;SharedAccessKey=test", "topic"));
+
+        MessageBody body = MessageBody.fromValueData("Test message body".getBytes());
+        when(message.getMessageId()).thenReturn(UUID.randomUUID().toString());
+        when(message.getBody()).thenReturn(body.toString().getBytes());
+        when(message.getProperties()).thenReturn(Map.of("key", "value"));
+        when(message.getScheduledEnqueueTimeUtc()).thenReturn(Instant.now().plus(Duration.ofMinutes(5)));
+
+        when(client.sendAsync(any(IMessage.class))).thenReturn(CompletableFuture.completedFuture(null));
+        doReturn(client).when(proxy).newTopicClient();
+
+        proxy.setKeepClientAlive(true);
+        proxy.send(message);
+
+        verify(client, times(1)).send(any(IMessage.class));
+        verify(client, never()).close();
     }
 }

--- a/api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/cve-resolution-strategy.gradle
+++ b/cve-resolution-strategy.gradle
@@ -56,6 +56,11 @@ configurations.all {
             if (det.requested.group == 'org.apache.commons' && det.requested.name == 'commons-lang3') {
                 det.useVersion '3.18.0'
             }
+
+            if (det.requested.group == 'net.bytebuddy' && det.requested.name == 'byte-buddy') {
+                det.useVersion '1.17.7'
+            }
+
         }
     }
 }

--- a/cve-resolution-strategy.gradle
+++ b/cve-resolution-strategy.gradle
@@ -14,13 +14,6 @@ configurations.all {
                 det.useVersion '11.0.25'
             }
 
-            /*
-                For compatibility with Powermockito
-            */
-            if (det.requested.group == 'org.mockito') {
-                det.useVersion '3.12.1'
-            }
-
             /* CVE-2025-31672 */
             if (det.requested.name == 'org.apache.poi') {
                 det.useVersion '5.4.1'
@@ -56,11 +49,6 @@ configurations.all {
             if (det.requested.group == 'org.apache.commons' && det.requested.name == 'commons-lang3') {
                 det.useVersion '3.18.0'
             }
-
-            if (det.requested.group == 'net.bytebuddy' && det.requested.name == 'byte-buddy') {
-                det.useVersion '1.17.7'
-            }
-
         }
     }
 }

--- a/gov-pay-client/build.gradle
+++ b/gov-pay-client/build.gradle
@@ -5,5 +5,4 @@ dependencies {
     implementation group: 'io.github.resilience4j', name: 'resilience4j-spring-boot3', version: '2.2.0'
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2'
     testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '3.0.1'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'
 }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -35,4 +35,5 @@ dependencies {
     testImplementation(group: 'com.mmnaseri.utils', name: 'spring-data-mock', version:'2.2.0') {
       exclude(module: 'commons-logging')
     }
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.19.0'
 }

--- a/model/src/test/java/uk/gov/hmcts/payment/api/model/CheckDigitTest.java
+++ b/model/src/test/java/uk/gov/hmcts/payment/api/model/CheckDigitTest.java
@@ -4,7 +4,7 @@ import org.apache.commons.validator.routines.checkdigit.CheckDigitException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.payment.api.util.CheckDigitUtil;
 
 import java.util.Arrays;


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-8047

### Change description
For Ways2Pay PBA payments, the apportionment update was carried out after a ServiceBus call to update services with the payment status. On rare occasions however the SB call would fail, meaning the apportionment table wouldn't be updated.

This update moves the apportionment code to before the Servicebus call and adds extra logging around the SB call to diagnose issues the send message process which can appear to hang the SB is unavailable. If an exception get's raised then it will attempt a retry. 

### Testing done
Observed in Demo

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
