### PR TITLE
PAY-8065: Updating volume to be 1 if null

### DIFF
--- a/api/src/main/resources/db/changelog/db.changelog-0.1.16.yaml
+++ b/api/src/main/resources/db/changelog/db.changelog-0.1.16.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1810000000000-3
+      author: DaveJ
+      changes:
+        - sql:
+            splitStatements: true
+            sql: >
+              UPDATE fee SET volume = 1 WHERE volume IS NULL;

--- a/api/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/api/src/main/resources/db/changelog/db.changelog-master.xml
@@ -28,4 +28,5 @@
     <include file="db/changelog/db.changelog-0.1.13.yaml"/>
     <include file="db/changelog/db.changelog-0.1.14.yaml"/>
     <include file="db/changelog/db.changelog-0.1.15.yaml"/>
+    <include file="db/changelog/db.changelog-0.1.16.yaml"/>
 </databaseChangeLog>

--- a/charts/payment-api/Chart.yaml
+++ b/charts/payment-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Helm chart for the HMCTS payment api
 name: payment-api
 home: https://github.com/hmcts/ccpay-payment-app
-version: 2.3.60
+version: 2.3.59
 maintainers:
   - name: HMCTS Fees & Payments Dev Team
     email: ccpay@hmcts.net

--- a/charts/payment-api/Chart.yaml
+++ b/charts/payment-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Helm chart for the HMCTS payment api
 name: payment-api
 home: https://github.com/hmcts/ccpay-payment-app
-version: 2.3.59
+version: 2.3.60
 maintainers:
   - name: HMCTS Fees & Payments Dev Team
     email: ccpay@hmcts.net


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-8065

### Change description
Volume defaults to 1, but older fee records are still showing null values which causes issues when refunding.

### Testing done
Functional tests and manual testing, also this was covered extensively in PAY-7625.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
