### PR TITLE
PAY-8104: Update build.gradle to fix pact tests

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -183,7 +183,7 @@ dependencies {
     contractTestImplementation group: 'au.com.dius.pact.provider', name: 'spring', version: versions.pact_version
     contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5spring', version: versions.pact_version
     contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: versions.pact_version
-    contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'java8', version: '4.1.43'
+    contractTestImplementation group: 'au.com.dius.pact', name: 'consumer', version: versions.pact_version
     contractTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
     contractTestImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
     contractTestImplementation("org.junit.jupiter:junit-jupiter-engine:5.10.2")

--- a/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/consumer/ReferenceDataLocationConsumerTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/payment/api/controllers/consumer/ReferenceDataLocationConsumerTest.java
@@ -29,7 +29,7 @@ import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import java.util.Collections;
 import java.util.Optional;
 
-import static io.pactfoundation.consumer.dsl.LambdaDsl.newJsonArray;
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonArray;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.BDDMockito.given;


### PR DESCRIPTION
Minor change to Java8 version for contract tests

### Jira link
https://tools.hmcts.net/jira/browse/PAY-8104


### Change description
Minor version to pact libary as referenced version isn't available.


### Testing done
Pipeline passes

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
