### PR TITLE
PAY-8236: Trim reconcliation fee version fields

### DIFF
--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
@@ -387,8 +387,16 @@ public class PaymentDtoMapper {
 
                     Optional<FeeVersionDto> optionalFeeVersionDto = feesService.getFeeVersion(fee.getCode(), fee.getVersion());
                     if (optionalFeeVersionDto.isPresent()) {
-                        fee.setMemoLine(optionalFeeVersionDto.get().getMemoLine());
-                        fee.setNaturalAccountCode(optionalFeeVersionDto.get().getNaturalAccountCode());
+                        fee.setMemoLine(
+                            optionalFeeVersionDto.get().getMemoLine() != null
+                                ? optionalFeeVersionDto.get().getMemoLine().trim()
+                                : null
+                        );
+                        fee.setNaturalAccountCode(
+                            optionalFeeVersionDto.get().getNaturalAccountCode() != null
+                                ? optionalFeeVersionDto.get().getNaturalAccountCode().trim()
+                                : null
+                        );
                     }
                 } else {
                     LOG.info("No fee found with the code: {}", fee.getCode());


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-8236

### Change description
For the new FEE0564, the policy team introduced a leading space for the fields natural account code and memo line. This unfortunatetly causes an issue on the Liberata reconciliation pull which prevents any payments associated to this fee being processed. Currently the following payments are affected.
- RC-1763-3749-9163-4068,
- RC-1763-3756-3536-8724,
- RC-1763-3733-5443-9438.
- RC-1763-3782-2529-0167.

This update trims the white spaces for both the natural account code and memo line when producing the /reconciliation-payments for Liberata. The business will speak with the Policy team to correct the data at the source at a later date. 

### Testing done
Unit test added, plus the reconciliation report as been run in the lower environment (which has a copy of the fee register with the spaces in the fee) and this has proven successful.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
