### PR TITLE
PAY-8780: Fix missing banked date from payment reconciliation

### DIFF
--- a/api-contract/src/main/java/uk/gov/hmcts/payment/api/contract/ReconciliationPaymentDto.java
+++ b/api-contract/src/main/java/uk/gov/hmcts/payment/api/contract/ReconciliationPaymentDto.java
@@ -80,6 +80,8 @@ public class ReconciliationPaymentDto {
 
     private String documentControlNumber;
 
+    private Date bankedDate;
+
     private String payerName;
 
     private Boolean refundEnable;

--- a/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/dto/mapper/PaymentDtoMapper.java
@@ -641,6 +641,7 @@ public class PaymentDtoMapper {
             .externalReference(paymentDto.getExternalReference())
             .reportedDateOffline(paymentDto.getReportedDateOffline())
             .documentControlNumber(paymentDto.getDocumentControlNumber())
+            .bankedDate(paymentDto.getBankedDate())
             .payerName(paymentDto.getPayerName())
             .refundEnable(paymentDto.getRefundEnable())
             .fees(toReconciliationFeeDtos(paymentDto.getFees()))

--- a/api/src/test/java/uk/gov/hmcts/payment/api/mapper/PaymentDtoMapperTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/mapper/PaymentDtoMapperTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.payment.api.configuration.LaunchDarklyFeatureToggler;
 import uk.gov.hmcts.payment.api.contract.FeeDto;
 import uk.gov.hmcts.payment.api.contract.PaymentAllocationDto;
 import uk.gov.hmcts.payment.api.contract.PaymentDto;
+import uk.gov.hmcts.payment.api.contract.ReconciliationPaymentDto;
 import uk.gov.hmcts.payment.api.dto.mapper.PaymentDtoMapper;
 import uk.gov.hmcts.payment.api.model.*;
 import uk.gov.hmcts.payment.api.reports.FeesService;
@@ -328,6 +329,13 @@ public class PaymentDtoMapperTest {
 
         PaymentDto paymentDto = paymentDtoMapper.toRetrieveCardPaymentResponseDtoWithoutExtReference(paymentFeeLink, "abc");
         assertEquals(paymentDto.getCaseReference(), payment.getCaseReference());
+    }
+
+    @Test
+    public void testToReconciliationPaymentDtoMapsBankedDate() {
+        PaymentDto paymentDto = paymentDtoMapper.toGetPaymentResponseDtos(payment1);
+        ReconciliationPaymentDto reconciliationPaymentDto = paymentDtoMapper.toReconciliationPaymentDto(paymentDto);
+        assertEquals(paymentDto.getBankedDate(), reconciliationPaymentDto.getBankedDate());
     }
 
     @Test


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-8780

Related to: https://tools.hmcts.net/jira/browse/PAY-8144

### Change description
Reconciliation payments was changed to a new reponse obeject to clean up the unwanted additional tags. This unfortunately resulted in a missing banked_date field which has now been corrected.

### Testing done
Unit test added, manual check performed on PR.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
