### PR TITLE
HDPI-6601: Allow retry of PBA payment if original account was deleted

### DIFF
--- a/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/IdempotencyServiceImpl.java
+++ b/api/src/main/java/uk/gov/hmcts/payment/api/domain/service/IdempotencyServiceImpl.java
@@ -17,7 +17,7 @@ public class IdempotencyServiceImpl implements IdempotencyService {
     @Autowired
     private IdempotencyKeysRepository idempotencyKeysRepository;
 
-    private static final int HTTP_CODE_ALLOWABLE_RETRIES[] = { 504, 500, 412, 402 };
+    private static final int HTTP_CODE_ALLOWABLE_RETRIES[] = { 504, 500, 412, 402, 410 };
 
     @Override
     public Optional<IdempotencyKeys> findTheRecordByIdempotencyKey(String idempotencyKeyToCheck) {

--- a/api/src/test/java/uk/gov/hmcts/payment/api/domain/service/IdempotencyServiceImplTest.java
+++ b/api/src/test/java/uk/gov/hmcts/payment/api/domain/service/IdempotencyServiceImplTest.java
@@ -132,4 +132,18 @@ public class IdempotencyServiceImplTest {
         assertEquals("idempKey02", response.get(0).getIdempotencyKey());
         assertEquals("idempKey04", response.get(1).getIdempotencyKey());
     }
+
+    @Test
+    public void filterRecordsWithAcceptableLiberataDeletedAccountHttpResponseTest() {
+
+        IdempotencyKeys completedGoneIdempotencyKeys = IdempotencyKeys.idempotencyKeysWith().responseCode(HttpStatus.GONE.value())
+            .requestHashcode(-1316086963).idempotencyKey("idam-key-0-0616666535632896").requestBody("")
+            .responseStatus(IdempotencyKeys.ResponseStatusType.completed).build();
+
+        List<IdempotencyKeys> idempotencyKeysList = List.of(completedGoneIdempotencyKeys);
+
+        List<IdempotencyKeys> response = idempotencyServiceImpl.filterRecordsWithAcceptableLiberataHttpResponse(idempotencyKeysList);
+        assertNotNull(response);
+        assertEquals(0, response.size());
+    }
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/HDPI-6601

### Change description
Updated HTTP_CODE_ALLOWABLE_RETRIES to include HTTP 410 which is the Liberata response for deleted PBA accounts. This should not block a PBA payment against a Service Request as users should be able to retry using another PBA account.

This is the evidence in the DB (idempotency_keys) for capturing the deleted PBA account.
`
13049	"idam-key-0-0616666535632896"	-1316086963	"{""currency"":""GBP"",""amount"":404,""customer_reference"":""test"",""account_number"":""PBA0095040"",""idempotency_key"":""idam-key-0-0616666535632896"",""organisation_name"":""Possession Claim Service Org1""}"	410	"{""payment_reference"":""RC-1782-4660-1784-7620"",""status"":""failed"",""date_created"":""Fri Jun 26 09:26:58 GMT 2026"",""error"":{""error_code"":""CA-E0004"",""error_message"":""Your account is deleted""}}"	"2026-06-26 09:26:57.788"	"2026-06-26 09:26:58.927"	"completed"
`

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done
Unit testing done, tested by Service.


### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
